### PR TITLE
feat: add chat with OpenAI for teting purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ This section outlines the full process for setting up the environment and runnin
 ## Contributing
 
 As this is a PoC, formal contributions are not the primary focus. However, if you find a bug or have a suggestion, feel free to open an issue.
-

--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ This section outlines the full process for setting up the environment and runnin
 
     The script will enter an interactive loop. You can now ask questions about your deployments in natural language.
 
+<div align="center">
+
 <img src="https://raw.githubusercontent.com/shini4i/assets/main/src/argo-watcher-mcp/argo-watcher-mcp-chat.png" alt="Showcase" height="441" width="680">
+
+</div>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,50 @@ A simple service that exposes an [argo-watcher](https://github.com/shini4i/argo-
 
 ## Usage
 
-For now, there are no clear instructions for using this project.
+This section outlines the full process for setting up the environment and running the interactive AI chat client.
 
-For simple testing purposes, there is an example script `scripts/test.py`.
+1.  **Bootstrap `argo-watcher` Service**
+
+    The MCP server depends on a running `argo-watcher` instance. You can quickly bootstrap this service using the official `docker-compose.yml` from the [argo-watcher repository](https://github.com/shini4i/argo-watcher/blob/main/docker-compose.yml).
+
+    ```bash
+    # In a separate terminal, from the argo-watcher project directory:
+    docker-compose up
+    ```
+
+2.  **Start `argo-watcher-mcp` Server**
+
+    With `argo-watcher` running, start the MCP server. This project includes a convenience task for this purpose.
+
+    ```bash
+    # From this project's root directory:
+    task run
+    ```
+
+3.  **Configure OpenAI Credentials**
+
+    The AI chat client requires an OpenAI API key. Export it as an environment variable in the terminal where you plan to run the chat.
+
+    ```bash
+    export OPENAI_API_KEY="sk-..."
+    ```
+
+4.  **Launch the Interactive AI Chat**
+
+    Finally, run the AI chat client using its pre-configured task.
+
+    ```bash
+    # This will start the interactive chat session.
+    task chat
+    ```
+
+5.  **Ask Questions**
+
+    The script will enter an interactive loop. You can now ask questions about your deployments in natural language.
+
+<img src="https://raw.githubusercontent.com/shini4i/assets/main/src/argo-watcher-mcp/argo-watcher-mcp-chat.png" alt="Showcase" height="441" width="680">
 
 ## Contributing
 
 As this is a PoC, formal contributions are not the primary focus. However, if you find a bug or have a suggestion, feel free to open an issue.
+

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,3 +26,10 @@ tasks:
     desc: "Bump the minor version"
     cmds:
       - bump2version minor --allow-dirty
+
+  chat:
+    desc: "Launch interactive chat with OpenAI"
+    cmds:
+      - ./scripts/ai-chat.py
+    requires:
+      vars: [OPENAI_API_KEY]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   deps:
     desc: "Install project dependencies using Poetry."
     cmds:
-      - poetry install
+      - poetry install --with dev,chat
     sources:
       - pyproject.toml
       - poetry.lock

--- a/poetry.lock
+++ b/poetry.lock
@@ -6,7 +6,7 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -18,7 +18,7 @@ version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
     {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
@@ -34,12 +34,28 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "asttokens"
+version = "3.0.0"
+description = "Annotate AST trees with source code positions"
+optional = false
+python-versions = ">=3.8"
+groups = ["chat"]
+files = [
+    {file = "asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2"},
+    {file = "asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7"},
+]
+
+[package.extras]
+astroid = ["astroid (>=2,<4)"]
+test = ["astroid (>=2,<4)", "pytest", "pytest-cov", "pytest-xdist"]
+
+[[package]]
 name = "certifi"
 version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
     {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
@@ -51,7 +67,7 @@ version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
     {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
@@ -66,7 +82,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -154,6 +170,33 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = false
+python-versions = ">=3.6"
+groups = ["chat"]
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
+name = "executing"
+version = "2.2.0"
+description = "Get the currently executing AST node of a frame, and other information"
+optional = false
+python-versions = ">=3.8"
+groups = ["chat"]
+files = [
+    {file = "executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa"},
+    {file = "executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755"},
+]
+
+[package.extras]
+tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
+
+[[package]]
 name = "fastapi"
 version = "0.115.13"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -195,7 +238,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -207,7 +250,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -229,7 +272,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -261,12 +304,30 @@ files = [
 ]
 
 [[package]]
+name = "icecream"
+version = "2.1.5"
+description = "Never use print() to debug again; inspect variables, expressions, and program execution with a single, simple function call."
+optional = false
+python-versions = "*"
+groups = ["chat"]
+files = [
+    {file = "icecream-2.1.5-py3-none-any.whl", hash = "sha256:c020917c5cb180a528dbba170250ccd8b74ebc75f2a7a8e839819bf959b9f80c"},
+    {file = "icecream-2.1.5.tar.gz", hash = "sha256:14d21e3383326a69a8c1a3bcf11f83283459f0d269ece5af83fce2c0d663efec"},
+]
+
+[package.dependencies]
+asttokens = ">=2.0.1"
+colorama = ">=0.3.9"
+executing = ">=2.1.0"
+pygments = ">=2.2.0"
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -288,12 +349,99 @@ files = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.10.0"
+description = "Fast iterable JSON parser."
+optional = false
+python-versions = ">=3.9"
+groups = ["chat"]
+files = [
+    {file = "jiter-0.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:cd2fb72b02478f06a900a5782de2ef47e0396b3e1f7d5aba30daeb1fce66f303"},
+    {file = "jiter-0.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32bb468e3af278f095d3fa5b90314728a6916d89ba3d0ffb726dd9bf7367285e"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa8b3e0068c26ddedc7abc6fac37da2d0af16b921e288a5a613f4b86f050354f"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:286299b74cc49e25cd42eea19b72aa82c515d2f2ee12d11392c56d8701f52224"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ed5649ceeaeffc28d87fb012d25a4cd356dcd53eff5acff1f0466b831dda2a7"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2ab0051160cb758a70716448908ef14ad476c3774bd03ddce075f3c1f90a3d6"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03997d2f37f6b67d2f5c475da4412be584e1cec273c1cfc03d642c46db43f8cf"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c404a99352d839fed80d6afd6c1d66071f3bacaaa5c4268983fc10f769112e90"},
+    {file = "jiter-0.10.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66e989410b6666d3ddb27a74c7e50d0829704ede652fd4c858e91f8d64b403d0"},
+    {file = "jiter-0.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b532d3af9ef4f6374609a3bcb5e05a1951d3bf6190dc6b176fdb277c9bbf15ee"},
+    {file = "jiter-0.10.0-cp310-cp310-win32.whl", hash = "sha256:da9be20b333970e28b72edc4dff63d4fec3398e05770fb3205f7fb460eb48dd4"},
+    {file = "jiter-0.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:f59e533afed0c5b0ac3eba20d2548c4a550336d8282ee69eb07b37ea526ee4e5"},
+    {file = "jiter-0.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3bebe0c558e19902c96e99217e0b8e8b17d570906e72ed8a87170bc290b1e978"},
+    {file = "jiter-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:558cc7e44fd8e507a236bee6a02fa17199ba752874400a0ca6cd6e2196cdb7dc"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d613e4b379a07d7c8453c5712ce7014e86c6ac93d990a0b8e7377e18505e98d"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f62cf8ba0618eda841b9bf61797f21c5ebd15a7a1e19daab76e4e4b498d515b2"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:919d139cdfa8ae8945112398511cb7fca58a77382617d279556b344867a37e61"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13ddbc6ae311175a3b03bd8994881bc4635c923754932918e18da841632349db"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c440ea003ad10927a30521a9062ce10b5479592e8a70da27f21eeb457b4a9c5"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc347c87944983481e138dea467c0551080c86b9d21de6ea9306efb12ca8f606"},
+    {file = "jiter-0.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:13252b58c1f4d8c5b63ab103c03d909e8e1e7842d302473f482915d95fefd605"},
+    {file = "jiter-0.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7d1bbf3c465de4a24ab12fb7766a0003f6f9bce48b8b6a886158c4d569452dc5"},
+    {file = "jiter-0.10.0-cp311-cp311-win32.whl", hash = "sha256:db16e4848b7e826edca4ccdd5b145939758dadf0dc06e7007ad0e9cfb5928ae7"},
+    {file = "jiter-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c9c1d5f10e18909e993f9641f12fe1c77b3e9b533ee94ffa970acc14ded3812"},
+    {file = "jiter-0.10.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1e274728e4a5345a6dde2d343c8da018b9d4bd4350f5a472fa91f66fda44911b"},
+    {file = "jiter-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7202ae396446c988cb2a5feb33a543ab2165b786ac97f53b59aafb803fef0744"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23ba7722d6748b6920ed02a8f1726fb4b33e0fd2f3f621816a8b486c66410ab2"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:371eab43c0a288537d30e1f0b193bc4eca90439fc08a022dd83e5e07500ed026"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c675736059020365cebc845a820214765162728b51ab1e03a1b7b3abb70f74c"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0c5867d40ab716e4684858e4887489685968a47e3ba222e44cde6e4a2154f959"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395bb9a26111b60141757d874d27fdea01b17e8fac958b91c20128ba8f4acc8a"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6842184aed5cdb07e0c7e20e5bdcfafe33515ee1741a6835353bb45fe5d1bd95"},
+    {file = "jiter-0.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:62755d1bcea9876770d4df713d82606c8c1a3dca88ff39046b85a048566d56ea"},
+    {file = "jiter-0.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:533efbce2cacec78d5ba73a41756beff8431dfa1694b6346ce7af3a12c42202b"},
+    {file = "jiter-0.10.0-cp312-cp312-win32.whl", hash = "sha256:8be921f0cadd245e981b964dfbcd6fd4bc4e254cdc069490416dd7a2632ecc01"},
+    {file = "jiter-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:a7c7d785ae9dda68c2678532a5a1581347e9c15362ae9f6e68f3fdbfb64f2e49"},
+    {file = "jiter-0.10.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e0588107ec8e11b6f5ef0e0d656fb2803ac6cf94a96b2b9fc675c0e3ab5e8644"},
+    {file = "jiter-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cafc4628b616dc32530c20ee53d71589816cf385dd9449633e910d596b1f5c8a"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:520ef6d981172693786a49ff5b09eda72a42e539f14788124a07530f785c3ad6"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:554dedfd05937f8fc45d17ebdf298fe7e0c77458232bcb73d9fbbf4c6455f5b3"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bc299da7789deacf95f64052d97f75c16d4fc8c4c214a22bf8d859a4288a1c2"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5161e201172de298a8a1baad95eb85db4fb90e902353b1f6a41d64ea64644e25"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e2227db6ba93cb3e2bf67c87e594adde0609f146344e8207e8730364db27041"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:15acb267ea5e2c64515574b06a8bf393fbfee6a50eb1673614aa45f4613c0cca"},
+    {file = "jiter-0.10.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:901b92f2e2947dc6dfcb52fd624453862e16665ea909a08398dde19c0731b7f4"},
+    {file = "jiter-0.10.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d0cb9a125d5a3ec971a094a845eadde2db0de85b33c9f13eb94a0c63d463879e"},
+    {file = "jiter-0.10.0-cp313-cp313-win32.whl", hash = "sha256:48a403277ad1ee208fb930bdf91745e4d2d6e47253eedc96e2559d1e6527006d"},
+    {file = "jiter-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:75f9eb72ecb640619c29bf714e78c9c46c9c4eaafd644bf78577ede459f330d4"},
+    {file = "jiter-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:28ed2a4c05a1f32ef0e1d24c2611330219fed727dae01789f4a335617634b1ca"},
+    {file = "jiter-0.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14a4c418b1ec86a195f1ca69da8b23e8926c752b685af665ce30777233dfe070"},
+    {file = "jiter-0.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:d7bfed2fe1fe0e4dda6ef682cee888ba444b21e7a6553e03252e4feb6cf0adca"},
+    {file = "jiter-0.10.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:5e9251a5e83fab8d87799d3e1a46cb4b7f2919b895c6f4483629ed2446f66522"},
+    {file = "jiter-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:023aa0204126fe5b87ccbcd75c8a0d0261b9abdbbf46d55e7ae9f8e22424eeb8"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c189c4f1779c05f75fc17c0c1267594ed918996a231593a21a5ca5438445216"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:15720084d90d1098ca0229352607cd68256c76991f6b374af96f36920eae13c4"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4f2fb68e5f1cfee30e2b2a09549a00683e0fde4c6a2ab88c94072fc33cb7426"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce541693355fc6da424c08b7edf39a2895f58d6ea17d92cc2b168d20907dee12"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31c50c40272e189d50006ad5c73883caabb73d4e9748a688b216e85a9a9ca3b9"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fa3402a2ff9815960e0372a47b75c76979d74402448509ccd49a275fa983ef8a"},
+    {file = "jiter-0.10.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:1956f934dca32d7bb647ea21d06d93ca40868b505c228556d3373cbd255ce853"},
+    {file = "jiter-0.10.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:fcedb049bdfc555e261d6f65a6abe1d5ad68825b7202ccb9692636c70fcced86"},
+    {file = "jiter-0.10.0-cp314-cp314-win32.whl", hash = "sha256:ac509f7eccca54b2a29daeb516fb95b6f0bd0d0d8084efaf8ed5dfc7b9f0b357"},
+    {file = "jiter-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ed975b83a2b8639356151cef5c0d597c68376fc4922b45d0eb384ac058cfa00"},
+    {file = "jiter-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aa96f2abba33dc77f79b4cf791840230375f9534e5fac927ccceb58c5e604a5"},
+    {file = "jiter-0.10.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:bd6292a43c0fc09ce7c154ec0fa646a536b877d1e8f2f96c19707f65355b5a4d"},
+    {file = "jiter-0.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39de429dcaeb6808d75ffe9effefe96a4903c6a4b376b2f6d08d77c1aaee2f18"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52ce124f13a7a616fad3bb723f2bfb537d78239d1f7f219566dc52b6f2a9e48d"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:166f3606f11920f9a1746b2eea84fa2c0a5d50fd313c38bdea4edc072000b0af"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:28dcecbb4ba402916034fc14eba7709f250c4d24b0c43fc94d187ee0580af181"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86c5aa6910f9bebcc7bc4f8bc461aff68504388b43bfe5e5c0bd21efa33b52f4"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ceeb52d242b315d7f1f74b441b6a167f78cea801ad7c11c36da77ff2d42e8a28"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ff76d8887c8c8ee1e772274fcf8cc1071c2c58590d13e33bd12d02dc9a560397"},
+    {file = "jiter-0.10.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a9be4d0fa2b79f7222a88aa488bd89e2ae0a0a5b189462a12def6ece2faa45f1"},
+    {file = "jiter-0.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ab7fd8738094139b6c1ab1822d6f2000ebe41515c537235fd45dabe13ec9324"},
+    {file = "jiter-0.10.0-cp39-cp39-win32.whl", hash = "sha256:5f51e048540dd27f204ff4a87f5d79294ea0aa3aa552aca34934588cf27023cf"},
+    {file = "jiter-0.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:1b28302349dc65703a9e4ead16f163b1c339efffbe1049c30a44b001a2a4fff9"},
+    {file = "jiter-0.10.0.tar.gz", hash = "sha256:07a7142c38aacc85194391108dc91b5b57093c978a9932bd86a36862759d9500"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
     {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
@@ -348,11 +496,39 @@ version = "0.1.2"
 description = "Markdown URL utilities"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+
+[[package]]
+name = "openai"
+version = "1.92.2"
+description = "The official Python library for the openai API"
+optional = false
+python-versions = ">=3.8"
+groups = ["chat"]
+files = [
+    {file = "openai-1.92.2-py3-none-any.whl", hash = "sha256:abb64bee7f2571709edf9a856f598ffe871730129a7d807a8a4d8d2958f5c842"},
+    {file = "openai-1.92.2.tar.gz", hash = "sha256:b571a79fc7e165e7d00e6963a8a95eb5f42b60ac89fd316f1dc0a2dac5c6fae1"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.11,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.6)"]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+realtime = ["websockets (>=13,<16)"]
+voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
 [[package]]
 name = "packaging"
@@ -388,7 +564,7 @@ version = "2.11.7"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b"},
     {file = "pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db"},
@@ -410,7 +586,7 @@ version = "2.33.2"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8"},
     {file = "pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d"},
@@ -546,7 +722,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -660,7 +836,7 @@ version = "14.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
     {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
@@ -703,7 +879,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "chat", "dev"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -749,6 +925,28 @@ anyio = ">=3.6.2,<5"
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "tqdm"
+version = "4.67.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+groups = ["chat"]
+files = [
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typer"
 version = "0.16.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -772,7 +970,7 @@ version = "4.14.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
     {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
@@ -784,7 +982,7 @@ version = "0.4.1"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "chat"]
 files = [
     {file = "typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51"},
     {file = "typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28"},
@@ -816,4 +1014,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "203596d820fa08b89397247836fea03bdd2a1af8fcc6a735b5960bf8a5507dd9"
+content-hash = "16ba92f29489084e7d03fb5c8469f39f8149bc09ff34ca49abedada80976be05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,9 @@ pytest = "^8.4.1"
 respx = "^0.22.0"
 freezegun = "^1.5.2"
 pytest-cov = "^6.2.1"
+
+[tool.poetry.group.chat.dependencies]
+openai = "^1.92.2"
+click = "^8.2.1"
+icecream = "^2.1.5"
+rich = "^14.0.0"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,4 +69,3 @@ The script is built using a modern, object-oriented approach for a clean and mai
     ./scripts/ai-chat.py --debug
     ```
     Once running, you can type your questions at the prompt. Type `exit` or `quit` to end the session.
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,41 +1,72 @@
-# ArgoWatcherMCP Test Script
+# Argo Watcher MCP - Client Scripts
 
-This directory contains `test.py`, an integration test client for the ArgoWatcherMCP server.
+This document describes the client scripts available in this repository for interacting with the Argo Watcher MCP server.
 
-## Purpose
+---
 
-The primary goal of this script is to provide an end-to-end test of the server's tools and functionality by simulating a client interaction. It serves as the canonical example for how to programmatically interact with an `mcp-server` using the `mcp==1.9.4` Python SDK, as the required process is non-trivial.
+## Integration Test Script (`test.py`)
 
-## Technical Implementation
+This script provides an end-to-end test of the server's tools and functionality by simulating a client interaction. It serves as the canonical example for how to programmatically interact with an `mcp-server` using the `mcp==1.9.4` Python SDK.
 
-The `mcp==1.9.4` library does not provide a single, high-level client object that handles both networking and protocol logic. Instead, the SDK is designed with a two-layer architecture that must be composed by the developer.
+### Technical Implementation
 
-1.  **Transport Layer (`sse_client`):** Found in `mcp.client.sse`, this context manager handles the low-level network connection via Server-Sent Events (SSE). It manages the connection lifecycle and provides a pair of in-memory streams for reading and writing data.
+The `mcp==1.9.4` library uses a two-layer architecture that must be composed by the developer:
 
-2.  **Session Layer (`ClientSession`):** Found in `mcp.client.session`, this class implements the logical Model Context Protocol. It takes the I/O streams from the transport layer and exposes high-level methods like `.initialize()`, `.list_tools()`, and `.call_tool()`.
+1.  **Transport Layer (`sse_client`):** Handles the low-level network connection via Server-Sent Events (SSE).
+2.  **Session Layer (`ClientSession`):** Implements the logical Model Context Protocol and exposes high-level methods like `.initialize()`, `.list_tools()`, and `.call_tool()`.
 
-The `test.py` script correctly implements this two-layer architecture.
+The `test.py` script correctly implements this architecture, including the mandatory multi-stage protocol handshake.
 
-### Protocol Handshake
+### Usage
 
-A successful connection requires a specific, multi-stage handshake which is handled automatically by the `ClientSession`'s `.initialize()` method:
-
-1.  **Connect (`GET`):** The client opens a persistent SSE stream to `/sse` to receive a unique session URL.
-2.  **Initialize (`POST`):** The client sends an `initialize` request to the session URL.
-3.  **Confirm (`POST`):** After receiving a successful result, the client sends a final `notifications/initialized` notification to confirm the handshake.
-
-Only after this sequence is complete can the session be used to execute commands like `tools/list` and `tools/call`.
-
-## Usage
-
-1.  Ensure all dependencies are installed and the poetry virtual environment is active.
-2.  Start the ArgoWatcherMCP server in one terminal. (It will require running argo-watcher instance)
+1.  Ensure all dependencies are installed and the Poetry virtual environment is active.
+2.  Start the ArgoWatcherMCP server in one terminal (this requires a running argo-watcher instance).
 3.  From the project root, run the test script in a second terminal:
 
     ```bash
     ./scripts/test.py
     ```
 
-The script will print its progress through each stage of the connection and handshake, then display the results of the tool calls. Any failure will be reported as a fatal error.
+The script will print its progress and the results of the tool calls.
 
-> By default, it will look for deployments of application "app".
+---
+
+## AI Chat Client (`ai-chat.py`)
+
+This is an interactive command-line application that allows you to have a stateful conversation with the Argo Watcher MCP server using a powerful Large Language Model (OpenAI's GPT-4o) for natural language understanding.
+
+### Purpose
+
+The AI chat client demonstrates a more advanced use case where natural language questions are used to query the server. The LLM understands the user's intent, determines which tool to use from the server, and formulates a final answer based on the data returned by the tool.
+
+### Technical Implementation
+
+The script is built using a modern, object-oriented approach for a clean and maintainable codebase:
+
+-   **`ArgoWatcherClient` Class:** Encapsulates all direct communication with the MCP server, including tool discovery and execution.
+-   **`ChatManager` Class:** Orchestrates the entire interactive session. It maintains the conversation history, sends requests to the LLM, and uses the `ArgoWatcherClient` to perform tool calls.
+-   **`click` and `rich`:** Used for creating a robust and user-friendly command-line interface with rich, formatted output (including Markdown).
+-   **Stateful Conversation:** The chat history is maintained across multiple turns, allowing for follow-up questions and context-aware interactions.
+
+### Usage
+
+1.  **Set Environment Variables:**
+    The script requires your OpenAI API key.
+    ```bash
+    export OPENAI_API_KEY="sk-..."
+    ```
+
+2.  **Start the ArgoWatcherMCP Server:**
+    Ensure the server is running, either locally or in Docker. See the main project `README.md` for instructions.
+
+3.  **Run the Chat Client:**
+    From the project root, run the script. It will enter an interactive loop.
+    ```bash
+    ./scripts/ai-chat.py
+    ```
+    You can also enable verbose debugging output with the `--debug` flag:
+    ```bash
+    ./scripts/ai-chat.py --debug
+    ```
+    Once running, you can type your questions at the prompt. Type `exit` or `quit` to end the session.
+

--- a/scripts/ai-chat.py
+++ b/scripts/ai-chat.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+An interactive, class-based command-line chat application for the ArgoWatcherMCP server.
+
+This script uses a structured, object-oriented approach and leverages the 'click'
+library for robust command-line interaction and error handling.
+"""
+
+import asyncio
+import json
+import os
+from urllib.parse import urlencode
+from typing import Any, Dict, List
+
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+# OpenAI imports
+from openai import AsyncOpenAI, OpenAIError
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+    ChatCompletionToolParam,
+)
+
+# CLI and Output imports
+import click
+from rich.console import Console
+from rich.markdown import Markdown
+from icecream import ic
+
+# --- Configuration ---
+BASE_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8000")
+SSE_INIT_PATH = "/sse"
+
+
+class ArgoWatcherClient:
+    """
+    A client responsible for all direct communication with the ArgoWatcher MCP server.
+    """
+    def __init__(self, base_url: str, sse_path: str):
+        self.base_url = base_url
+        self.sse_path = sse_path
+
+    def _get_init_url(self) -> str:
+        """Constructs the initial URL required to start an MCP session."""
+        init_command = {"mcp_version": "1.0", "method": "mcp.discovery.list_tools"}
+        query_params = urlencode({"p": json.dumps(init_command)})
+        return f"{self.base_url.rstrip('/')}/{self.sse_path.lstrip('/')}?{query_params}"
+
+    async def discover_tools(self) -> List[ChatCompletionToolParam]:
+        """Connects to the MCP server to discover the available tools."""
+        init_url = self._get_init_url()
+        openai_tools: List[ChatCompletionToolParam] = []
+        try:
+            async with sse_client(url=init_url) as (read_stream, write_stream):
+                session = ClientSession(read_stream=read_stream, write_stream=write_stream)
+                async with session:
+                    await session.initialize()
+                    mcp_tools_response = await session.list_tools()
+                    if hasattr(mcp_tools_response, 'tools'):
+                        for tool in mcp_tools_response.tools:
+                            openai_tools.append({
+                                "type": "function",
+                                "function": {
+                                    "name": tool.name,
+                                    "description": tool.description,
+                                    "parameters": tool.inputSchema,
+                                },
+                            })
+            return openai_tools
+        except Exception as e:
+            # Let exceptions bubble up to be handled by the main CLI function.
+            raise click.ClickException(f"Error discovering tools: {e}")
+
+    async def execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> str:
+        """Establishes a new connection to execute a single tool call."""
+        ic(f"🤖 Calling tool {tool_name} with arguments:", tool_args)
+        init_url = self._get_init_url()
+        try:
+            async with sse_client(url=init_url) as (read_stream, write_stream):
+                session = ClientSession(read_stream=read_stream, write_stream=write_stream)
+                async with session:
+                    await session.initialize()
+                    mcp_tool_result = await session.call_tool(name=tool_name, arguments=tool_args)
+                    if mcp_tool_result and mcp_tool_result.content:
+                        all_results = [json.loads(item.text) for item in mcp_tool_result.content if hasattr(item, 'text')]
+                        return json.dumps(all_results)
+                    return "[]"
+        except Exception as e:
+            # Raise a specific, user-friendly error.
+            raise click.ClickException(f"Error executing MCP tool '{tool_name}': {e}")
+
+
+class ChatManager:
+    """
+    Manages the interactive chat session, conversation history, and LLM interaction.
+    """
+    def __init__(self, mcp_client: ArgoWatcherClient, llm_client: AsyncOpenAI, console: Console):
+        self.mcp_client = mcp_client
+        self.llm_client = llm_client
+        self.console = console
+        self.messages: List[ChatCompletionMessageParam] = []
+        self.tools: List[ChatCompletionToolParam] = []
+
+    async def initialize(self):
+        """Discover tools before starting the chat."""
+        self.console.print("Discovering tools from MCP server...")
+        self.tools = await self.mcp_client.discover_tools()
+        if not self.tools:
+            # Raise an exception to be handled by the CLI error handler.
+            raise click.ClickException("No tools found on the server. Cannot start chat.")
+        self.console.print("[bold green]✔ Tools discovered successfully.[/bold green]")
+
+
+    async def handle_tool_calls(self, response_message):
+        """Processes tool calls requested by the LLM."""
+        ic("🧠 LLM decided to call a tool...")
+        for tool_call in response_message.tool_calls:
+            function_name = tool_call.function.name
+            function_args = json.loads(tool_call.function.arguments)
+            ic("LLM wants to call:", function_name, function_args)
+
+            function_response_str = await self.mcp_client.execute_tool(
+                tool_name=function_name,
+                tool_args=function_args,
+            )
+
+            ic("Raw response from tool:", function_response_str)
+            self.messages.append(
+                {
+                    "tool_call_id": tool_call.id,
+                    "role": "tool",
+                    "name": function_name,
+                    "content": function_response_str,
+                }
+            )
+
+        with self.console.status("[bold blue]Summarizing tool results...[/bold blue]", spinner="dots"):
+            second_response = await self.llm_client.chat.completions.create(
+                model="gpt-4o",
+                messages=self.messages,
+            )
+        final_answer = second_response.choices[0].message.content
+        self.messages.append(second_response.choices[0].message)
+        return final_answer
+
+    async def start_chat(self):
+        """The main interactive chat loop."""
+        await self.initialize()
+        self.console.print("\n[bold]Welcome to the Argo Watcher AI Assistant![/bold]")
+        self.console.print("Type your questions below, or type 'exit' or 'quit' to end the session.")
+
+        while True:
+            try:
+                prompt = self.console.input("[bold yellow]You: [/bold yellow]")
+                if prompt.lower() in ["exit", "quit"]:
+                    self.console.print("[bold]Goodbye![/bold]")
+                    break
+
+                self.messages.append({"role": "user", "content": prompt})
+
+                with self.console.status("[bold blue]Thinking...[/bold blue]", spinner="dots"):
+                    response = await self.llm_client.chat.completions.create(
+                        model="gpt-4o",
+                        messages=self.messages,
+                        tools=self.tools,
+                        tool_choice="auto",
+                    )
+                    response_message = response.choices[0].message
+                    self.messages.append(response_message)
+
+                if response_message.tool_calls:
+                    final_answer = await self.handle_tool_calls(response_message)
+                else:
+                    final_answer = response_message.content
+
+                self.console.print("\n[bold green]Assistant:[/bold green]")
+                self.console.print(Markdown(final_answer or "Sorry, I couldn't generate a response."))
+                self.console.print("-" * 50)
+
+            except (KeyboardInterrupt, EOFError):
+                self.console.print("\n[bold]Goodbye![/bold]")
+                break
+            except OpenAIError as e:
+                self.console.print(f"\n[bold red]An OpenAI API error occurred: {e}[/bold red]")
+                # Remove the last user message to allow retrying
+                self.messages.pop()
+            except Exception as e:
+                self.console.print(f"\n[bold red]An unexpected error occurred during the chat: {e}[/bold red]")
+
+
+@click.command()
+@click.option('--debug', is_flag=True, help="Enable debug output with icecream.")
+def cli(debug):
+    """An interactive CLI to chat with the Argo Watcher MCP server via an LLM."""
+    if not debug:
+        ic.disable()
+
+    # --- Use click for cleaner error handling ---
+    if not os.getenv("OPENAI_API_KEY"):
+        raise click.ClickException("The OPENAI_API_KEY environment variable is not set.")
+
+    try:
+        # Initialize clients and managers
+        llm_client = AsyncOpenAI()
+        console = Console()
+        mcp_client = ArgoWatcherClient(base_url=BASE_URL, sse_path=SSE_INIT_PATH)
+        chat_manager = ChatManager(mcp_client, llm_client, console)
+
+        # Run the main chat loop
+        asyncio.run(chat_manager.start_chat())
+
+    except click.ClickException:
+        # Re-raise to let click handle the exit and message.
+        raise
+    except Exception as e:
+        # Catch any other unexpected startup errors.
+        raise click.ClickException(f"Failed to start the application: {e}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/ai-chat.py
+++ b/scripts/ai-chat.py
@@ -2,32 +2,26 @@
 # -*- coding: utf-8 -*-
 """
 An interactive, class-based command-line chat application for the ArgoWatcherMCP server.
-
-This script uses a structured, object-oriented approach and leverages the 'click'
-library for robust command-line interaction and error handling.
 """
-
 import asyncio
 import json
+import logging
 import os
-from urllib.parse import urlencode
 from typing import Any, Dict, List
+from urllib.parse import urlencode
 
+import click
+from icecream import ic
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
-
-# OpenAI imports
 from openai import AsyncOpenAI, OpenAIError
 from openai.types.chat import (
+    ChatCompletionMessage,
     ChatCompletionMessageParam,
     ChatCompletionToolParam,
 )
-
-# CLI and Output imports
-import click
 from rich.console import Console
 from rich.markdown import Markdown
-from icecream import ic
 
 # --- Configuration ---
 BASE_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8000")
@@ -35,9 +29,8 @@ SSE_INIT_PATH = "/sse"
 
 
 class ArgoWatcherClient:
-    """
-    A client responsible for all direct communication with the ArgoWatcher MCP server.
-    """
+    """A client for all direct communication with the ArgoWatcher MCP server."""
+
     def __init__(self, base_url: str, sse_path: str):
         self.base_url = base_url
         self.sse_path = sse_path
@@ -54,23 +47,26 @@ class ArgoWatcherClient:
         openai_tools: List[ChatCompletionToolParam] = []
         try:
             async with sse_client(url=init_url) as (read_stream, write_stream):
-                session = ClientSession(read_stream=read_stream, write_stream=write_stream)
+                session = ClientSession(
+                    read_stream=read_stream, write_stream=write_stream
+                )
                 async with session:
                     await session.initialize()
                     mcp_tools_response = await session.list_tools()
-                    if hasattr(mcp_tools_response, 'tools'):
+                    if hasattr(mcp_tools_response, "tools"):
                         for tool in mcp_tools_response.tools:
-                            openai_tools.append({
-                                "type": "function",
-                                "function": {
-                                    "name": tool.name,
-                                    "description": tool.description,
-                                    "parameters": tool.inputSchema,
-                                },
-                            })
+                            openai_tools.append(  # type: ignore
+                                {
+                                    "type": "function",
+                                    "function": {
+                                        "name": tool.name,
+                                        "description": tool.description,
+                                        "parameters": tool.inputSchema,
+                                    },
+                                }
+                            )
             return openai_tools
         except Exception as e:
-            # Let exceptions bubble up to be handled by the main CLI function.
             raise click.ClickException(f"Error discovering tools: {e}")
 
     async def execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> str:
@@ -79,24 +75,35 @@ class ArgoWatcherClient:
         init_url = self._get_init_url()
         try:
             async with sse_client(url=init_url) as (read_stream, write_stream):
-                session = ClientSession(read_stream=read_stream, write_stream=write_stream)
+                session = ClientSession(
+                    read_stream=read_stream, write_stream=write_stream
+                )
                 async with session:
                     await session.initialize()
-                    mcp_tool_result = await session.call_tool(name=tool_name, arguments=tool_args)
+                    mcp_tool_result = await session.call_tool(
+                        name=tool_name, arguments=tool_args
+                    )
                     if mcp_tool_result and mcp_tool_result.content:
-                        all_results = [json.loads(item.text) for item in mcp_tool_result.content if hasattr(item, 'text')]
+                        all_results = [
+                            json.loads(item.text)
+                            for item in mcp_tool_result.content
+                            if hasattr(item, "text")
+                        ]
                         return json.dumps(all_results)
                     return "[]"
         except Exception as e:
-            # Raise a specific, user-friendly error.
             raise click.ClickException(f"Error executing MCP tool '{tool_name}': {e}")
 
 
 class ChatManager:
-    """
-    Manages the interactive chat session, conversation history, and LLM interaction.
-    """
-    def __init__(self, mcp_client: ArgoWatcherClient, llm_client: AsyncOpenAI, console: Console):
+    """Manages the interactive chat session, conversation history, and LLM interaction."""
+
+    def __init__(
+            self,
+            mcp_client: ArgoWatcherClient,
+            llm_client: AsyncOpenAI,
+            console: Console,
+    ):
         self.mcp_client = mcp_client
         self.llm_client = llm_client
         self.console = console
@@ -108,14 +115,31 @@ class ChatManager:
         self.console.print("Discovering tools from MCP server...")
         self.tools = await self.mcp_client.discover_tools()
         if not self.tools:
-            # Raise an exception to be handled by the CLI error handler.
-            raise click.ClickException("No tools found on the server. Cannot start chat.")
+            raise click.ClickException(
+                "No tools found on the server. Cannot start chat."
+            )
         self.console.print("[bold green]✔ Tools discovered successfully.[/bold green]")
 
+    def _add_message_to_history(self, message: ChatCompletionMessage):
+        """Type-safe method to add a message object to the conversation history."""
+        new_message: Dict[str, Any] = {"role": message.role}
 
-    async def handle_tool_calls(self, response_message):
+        if message.content:
+            new_message["content"] = message.content
+
+        if message.tool_calls:
+            new_message["tool_calls"] = [
+                tool_call.model_dump() for tool_call in message.tool_calls
+            ]
+
+        self.messages.append(new_message)  # type: ignore
+
+    async def handle_tool_calls(self, response_message: ChatCompletionMessage):
         """Processes tool calls requested by the LLM."""
         ic("🧠 LLM decided to call a tool...")
+        if not response_message.tool_calls:
+            return "Error: LLM tried to call a tool but none were provided."
+
         for tool_call in response_message.tool_calls:
             function_name = tool_call.function.name
             function_args = json.loads(tool_call.function.arguments)
@@ -127,7 +151,8 @@ class ChatManager:
             )
 
             ic("Raw response from tool:", function_response_str)
-            self.messages.append(
+
+            self.messages.append(  # type: ignore
                 {
                     "tool_call_id": tool_call.id,
                     "role": "tool",
@@ -136,20 +161,24 @@ class ChatManager:
                 }
             )
 
-        with self.console.status("[bold blue]Summarizing tool results...[/bold blue]", spinner="dots"):
+        with self.console.status(
+                "[bold blue]Summarizing tool results...[/bold blue]", spinner="dots"
+        ):
             second_response = await self.llm_client.chat.completions.create(
                 model="gpt-4o",
                 messages=self.messages,
             )
-        final_answer = second_response.choices[0].message.content
-        self.messages.append(second_response.choices[0].message)
-        return final_answer
+        final_response_message = second_response.choices[0].message
+        self._add_message_to_history(final_response_message)
+        return final_response_message.content
 
     async def start_chat(self):
         """The main interactive chat loop."""
         await self.initialize()
         self.console.print("\n[bold]Welcome to the Argo Watcher AI Assistant![/bold]")
-        self.console.print("Type your questions below, or type 'exit' or 'quit' to end the session.")
+        self.console.print(
+            "Type your questions below, or type 'exit' or 'quit' to end the session."
+        )
 
         while True:
             try:
@@ -158,9 +187,11 @@ class ChatManager:
                     self.console.print("[bold]Goodbye![/bold]")
                     break
 
-                self.messages.append({"role": "user", "content": prompt})
+                self.messages.append({"role": "user", "content": prompt})  # type: ignore
 
-                with self.console.status("[bold blue]Thinking...[/bold blue]", spinner="dots"):
+                with self.console.status(
+                        "[bold blue]Thinking...[/bold blue]", spinner="dots"
+                ):
                     response = await self.llm_client.chat.completions.create(
                         model="gpt-4o",
                         messages=self.messages,
@@ -168,7 +199,7 @@ class ChatManager:
                         tool_choice="auto",
                     )
                     response_message = response.choices[0].message
-                    self.messages.append(response_message)
+                    self._add_message_to_history(response_message)
 
                 if response_message.tool_calls:
                     final_answer = await self.handle_tool_calls(response_message)
@@ -176,46 +207,51 @@ class ChatManager:
                     final_answer = response_message.content
 
                 self.console.print("\n[bold green]Assistant:[/bold green]")
-                self.console.print(Markdown(final_answer or "Sorry, I couldn't generate a response."))
+                self.console.print(
+                    Markdown(final_answer or "Sorry, I couldn't generate a response.")
+                )
                 self.console.print("-" * 50)
 
             except (KeyboardInterrupt, EOFError):
                 self.console.print("\n[bold]Goodbye![/bold]")
                 break
             except OpenAIError as e:
-                self.console.print(f"\n[bold red]An OpenAI API error occurred: {e}[/bold red]")
-                # Remove the last user message to allow retrying
+                self.console.print(
+                    f"\n[bold red]An OpenAI API error occurred: {e}[/bold red]"
+                )
                 self.messages.pop()
             except Exception as e:
-                self.console.print(f"\n[bold red]An unexpected error occurred during the chat: {e}[/bold red]")
+                self.console.print(
+                    f"\n[bold red]An unexpected error occurred during the chat: {e}[/bold red]"
+                )
 
 
 @click.command()
-@click.option('--debug', is_flag=True, help="Enable debug output with icecream.")
+@click.option("--debug", is_flag=True, help="Enable debug output with icecream.")
 def cli(debug):
     """An interactive CLI to chat with the Argo Watcher MCP server via an LLM."""
     if not debug:
         ic.disable()
 
-    # --- Use click for cleaner error handling ---
+    # Set the log level for httpx to WARNING to hide INFO messages.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
     if not os.getenv("OPENAI_API_KEY"):
-        raise click.ClickException("The OPENAI_API_KEY environment variable is not set.")
+        raise click.ClickException(
+            "The OPENAI_API_KEY environment variable is not set."
+        )
 
     try:
-        # Initialize clients and managers
         llm_client = AsyncOpenAI()
         console = Console()
         mcp_client = ArgoWatcherClient(base_url=BASE_URL, sse_path=SSE_INIT_PATH)
         chat_manager = ChatManager(mcp_client, llm_client, console)
 
-        # Run the main chat loop
         asyncio.run(chat_manager.start_chat())
 
     except click.ClickException:
-        # Re-raise to let click handle the exit and message.
         raise
     except Exception as e:
-        # Catch any other unexpected startup errors.
         raise click.ClickException(f"Failed to start the application: {e}")
 
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+openai==1.92.2
+click==8.2.1
+icecream==2.1.5

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,0 @@
-openai==1.92.2
-click==8.2.1
-icecream==2.1.5


### PR DESCRIPTION
## Summary by Sourcery

Add a stateful, command-line AI chat client for the Argo Watcher MCP server, update documentation with setup and usage instructions, and extend the build configuration to include chat dependencies.

New Features:
- Add an interactive AI chat client (ai-chat.py) leveraging OpenAI’s GPT-4o for natural-language queries against the Argo Watcher MCP server.
- Introduce a new Taskfile “chat” task to launch the AI chat client.

Enhancements:
- Reorganize and expand scripts/README.md to document both the existing integration test script and the new AI chat client.
- Revise the project’s root README with detailed environment setup and usage steps for the AI chat workflow.
- Define a dedicated “chat” dependency group in pyproject.toml for OpenAI, click, icecream, and rich.

Build:
- Update Taskfile.yml to install chat dependencies with Poetry using the --with dev,chat flag.