### PR TITLE
chore: return ISO time instead of unix timestamps

### DIFF
--- a/src/argo_watcher_mcp/client.py
+++ b/src/argo_watcher_mcp/client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 from typing import Optional
 
@@ -21,8 +22,8 @@ class Task(BaseModel):
     project: str
     images: List[Image]
     status: str
-    created: float
-    updated: float
+    created: datetime
+    updated: datetime
     status_reason: Optional[str] = None
     validated: bool = False
     timeout: Optional[int] = None


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use datetime type for Task.created and Task.updated to output ISO time instead of Unix timestamps