### PR TITLE
chore: an attempt to make time handling less painful

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
-        args: ['--max-line-length', '100']
+        args: ['--max-line-length', '105']
   - repo: https://github.com/PyCQA/bandit.git
     rev: 1.8.5
     hooks:

--- a/scripts/instructions/process_deployments.md
+++ b/scripts/instructions/process_deployments.md
@@ -1,0 +1,17 @@
+You are an expert assistant for retrieving deployment information.
+
+### How to Handle Time Queries
+
+1.  **Absolute Dates & Times**: If the user provides any specific date or time (e.g., "yesterday", "on August 1st", "today at 8 pm"), you **MUST** convert it to a full datetime string in `"YYYY-MM-DDTHH:MM:SS"` format and use the `from_datetime` and/or `to_datetime` parameters.
+
+2.  **Relative Durations**: If the user provides a relative duration (e.g., "last 15 minutes", "past 3 hours"), you **MUST** use the `time_delta` parameter with a string like `"15m"` or `"3h"`.
+
+3.  **No Time Specified**: If the user does not specify any timeframe, you **MUST** use `time_delta: "1d"`.
+
+### How to Present Data
+
+1.  **Data Integrity**: You **MUST NOT** invent, shuffle, or change the data values returned by the tool. Your response should be well-formatted (e.g., a list or table), but the values must be unaltered.
+
+2.  **Grouping Logic**: When summarizing, you **MUST** group deployments as a single unit if they share the same `app` name and `tag`, but one image has a `/dkron` suffix.
+
+3.  **Finding the Last Deployment**: To find the "last" deployment, you **MUST** identify the result with the most recent `created` timestamp, not the `updated` timestamp.

--- a/src/argo_watcher_mcp/app.py
+++ b/src/argo_watcher_mcp/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from contextlib import asynccontextmanager
 
@@ -8,26 +9,52 @@ from argo_watcher_mcp.dependencies import app_state
 from argo_watcher_mcp.health import router as health_router
 from argo_watcher_mcp.tools import mcp
 
+EXCLUDED_LOG_PATHS = ["/healthz", "/readyz"]
+
+
+class AccessLogFilter(logging.Filter):
+    """
+    Filters out access logs for specified health check endpoints.
+    """
+    def filter(self, record: logging.LogRecord) -> bool:
+        # The request path is the 3rd element in the args tuple.
+        # e.g., ('127.0.0.1:8000', 'GET', '/healthz', '1.1', 200)
+        request_path = record.args[2]
+        return request_path not in EXCLUDED_LOG_PATHS
+
+
+class HttpxLogFilter(logging.Filter):
+    """
+    Filters out httpx logs originating from health checks.
+    """
+    def filter(self, record: logging.LogRecord) -> bool:
+        # For httpx, inspecting the message is more practical,
+        # but we do it safely without swallowing all exceptions.
+        message = record.getMessage()
+        # Return True to keep the log, False to discard it.
+        # We discard it if the name is 'httpx' and the message contains a health check path.
+        if record.name.startswith("httpx"):
+            return not any(path in message for path in EXCLUDED_LOG_PATHS)
+        return True
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
     Manages the application's startup and shutdown events.
     """
-    # On startup, create the httpx client and configure the shared state.
     argo_watcher_url = os.environ.get("ARGO_WATCHER_URL")
     if not argo_watcher_url:
         raise RuntimeError("ARGO_WATCHER_URL environment variable is not set.")
 
-    app_state.http_client = httpx.Client()
+    app_state.http_client = httpx.AsyncClient()
     app_state.argo_watcher_url = argo_watcher_url
 
     print("Application startup complete. HTTPX client created.")
     yield
 
-    # On shutdown, close the client.
-    if isinstance(app_state.http_client, httpx.Client):
-        app_state.http_client.close()
+    if isinstance(app_state.http_client, httpx.AsyncClient):
+        await app_state.http_client.aclose()
     print("Application shutdown complete. HTTPX client closed.")
 
 
@@ -41,8 +68,18 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    app.include_router(health_router, tags=["Health"])
+    # Configure logging to skip health check endpoints
+    access_logger = logging.getLogger("uvicorn.access")
+    for handler in access_logger.handlers:
+        handler.addFilter(AccessLogFilter())
 
+    # Suppress httpx logs from health checks
+    httpx_logger = logging.getLogger("httpx")
+    for handler in httpx_logger.handlers:
+        handler.addFilter(HttpxLogFilter())
+
+
+    app.include_router(health_router, tags=["Health"])
     app.mount("/", mcp.sse_app())
 
     return app

--- a/src/argo_watcher_mcp/client.py
+++ b/src/argo_watcher_mcp/client.py
@@ -30,25 +30,28 @@ class Task(BaseModel):
 
 
 class ArgoWatcherClient:
-    """A client for the argo-watcher API."""
+    """An ASYNCHRONOUS client for the argo-watcher API."""
 
-    def __init__(self, base_url: str, client: httpx.Client):
+    def __init__(self, base_url: str, client: httpx.AsyncClient):
+        """
+        The client must be an httpx.AsyncClient.
+        """
         self._base_url = base_url
         self._client = client
 
-    def check_health(self) -> None:
+    async def check_health(self) -> None:
         """
         Checks the health of the argo-watcher service by hitting its /healthz endpoint.
         Raises httpx.HTTPStatusError on a non-2xx response.
         """
-        response = self._client.get(f"{self._base_url}/healthz")
+        response = await self._client.get(f"{self._base_url}/healthz")
         response.raise_for_status()
 
-    def get_tasks(
-        self,
-        from_timestamp: int,
-        to_timestamp: Optional[int] = None,
-        app: Optional[str] = None,
+    async def get_tasks(
+            self,
+            from_timestamp: int,
+            to_timestamp: Optional[int] = None,
+            app: Optional[str] = None,
     ) -> List[Task]:
         """
         Fetches tasks from the argo-watcher /api/v1/tasks endpoint.
@@ -61,7 +64,7 @@ class ArgoWatcherClient:
 
         request_params = {k: v for k, v in params.items() if v is not None}
 
-        response = self._client.get(f"{self._base_url}/api/v1/tasks", params=request_params)
+        response = await self._client.get(f"{self._base_url}/api/v1/tasks", params=request_params)
         response.raise_for_status()
 
         response_data = response.json()

--- a/src/argo_watcher_mcp/dependencies.py
+++ b/src/argo_watcher_mcp/dependencies.py
@@ -4,7 +4,8 @@ from argo_watcher_mcp.client import ArgoWatcherClient
 
 
 class AppState:
-    http_client: httpx.Client | None = None
+    """Holds the shared state of the application."""
+    http_client: httpx.AsyncClient | None = None
     argo_watcher_url: str | None = None
 
 
@@ -18,8 +19,8 @@ def get_argo_client() -> ArgoWatcherClient:
     This function relies on the `app_state` object being populated
     by the application's lifespan manager.
     """
-    if not isinstance(app_state.http_client, httpx.Client) or not app_state.argo_watcher_url:
-        raise RuntimeError("Application state not initialized. Lifespan manager did not run.")
+    if not isinstance(app_state.http_client, httpx.AsyncClient) or not app_state.argo_watcher_url:
+        raise RuntimeError("Application state not initialized or is incorrect. Lifespan manager did not run correctly.")
 
     return ArgoWatcherClient(
         base_url=app_state.argo_watcher_url,

--- a/src/argo_watcher_mcp/health.py
+++ b/src/argo_watcher_mcp/health.py
@@ -27,13 +27,13 @@ def liveness_check() -> HealthStatus:
 
 
 @router.get("/readyz", response_model=HealthStatus)
-def readiness_check(argo_client: Annotated[ArgoWatcherClient, Depends(get_argo_client)]):
+async def readiness_check(argo_client: Annotated[ArgoWatcherClient, Depends(get_argo_client)]):
     """
     Checks if the application is ready to serve traffic by checking connectivity
     to the downstream argo-watcher service.
     """
     try:
-        argo_client.check_health()
+        await argo_client.check_health()
     except httpx.RequestError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/argo_watcher_mcp/tools.py
+++ b/src/argo_watcher_mcp/tools.py
@@ -56,10 +56,8 @@ def get_deployments(
     now = datetime.now(timezone.utc)
     to_timestamp = int(now.timestamp())
 
-    # Prioritize absolute datetime strings
     if from_datetime:
         try:
-            # FIX: Properly handle timezone-aware and naive datetime strings.
             start_dt = datetime.fromisoformat(from_datetime)
             if start_dt.tzinfo is None:
                 start_dt = start_dt.replace(tzinfo=timezone.utc)
@@ -76,17 +74,13 @@ def get_deployments(
                 to_timestamp = int(end_dt.timestamp())
 
         except ValueError:
-            # FIX: Raise an exception instead of returning a string in the list.
             raise ValueError("Invalid datetime format. Please use YYYY-MM-DDTHH:MM:SS.")
-    # Fall back to time_delta
     elif time_delta:
         try:
             delta = _parse_time_delta(time_delta)
             from_timestamp = int((now - delta).timestamp())
         except ValueError as e:
-            # FIX: Raise the exception instead of returning a string.
             raise e
-    # Default to 1 day
     else:
         delta = timedelta(days=1)
         from_timestamp = int((now - delta).timestamp())

--- a/src/argo_watcher_mcp/tools.py
+++ b/src/argo_watcher_mcp/tools.py
@@ -35,7 +35,7 @@ def _parse_time_delta(time_delta_str: str) -> timedelta:
 
 
 @mcp.tool()
-def get_deployments(
+async def get_deployments(
     app: Optional[str] = None,
     time_delta: Optional[str] = None,
     from_datetime: Optional[str] = None,  # Expects "YYYY-MM-DDTHH:MM:SS"
@@ -84,7 +84,7 @@ def get_deployments(
         delta = timedelta(days=1)
         from_timestamp = int((now - delta).timestamp())
 
-    return argo_client.get_tasks(
+    return await argo_client.get_tasks(
         from_timestamp=from_timestamp,
         to_timestamp=to_timestamp,
         app=app,

--- a/src/argo_watcher_mcp/tools.py
+++ b/src/argo_watcher_mcp/tools.py
@@ -23,7 +23,6 @@ mcp = FastMCP(
 
 def _parse_time_delta(time_delta_str: str) -> timedelta:
     """Parses a time delta string like '10m', '2h', or '7d'."""
-    # FIX: Add anchors (^) and ($) for exact matching.
     match = re.match(r"^(\d+)([mhd])$", time_delta_str.lower())
     if not match:
         raise ValueError("Invalid time delta format. Use '10m', '2h', or '7d'.")


### PR DESCRIPTION
## Summary by Sourcery

Enhance time-based filtering in the deployment tool, integrate an external instructions file into the interactive AI chat flow (including system context with current UTC time), update CLI handling and pre-commit formatting, and clean up related docstrings and error handling in scripts.

Enhancements:
- Support relative (`time_delta`) and absolute (`from_datetime`/`to_datetime`) time filters in `get_deployments`, defaulting to a one-day window.
- Introduce `_parse_time_delta` for parsing minute/hour/day strings and validate datetime inputs.
- Load base instructions from an external markdown file and prepend a system message (with current UTC timestamp) to every chat request.
- Require and read an instruction file in the CLI, raising an error if missing.

Build:
- Increase flake8 max-line-length to 105 in pre-commit config.

Documentation:
- Add `scripts/instructions/process_deployments.md` with guidelines for time handling and data presentation.

Chores:
- Remove redundant docstrings and refine JSON error handling in `scripts/ai-chat.py`.