### PR TITLE
chore: increase test coverage

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,24 +12,41 @@ import (
 	"github.com/shini4i/argo-watcher-mcp/internal/config"
 )
 
+type appRunner interface {
+	Run(context.Context) error
+}
+
+var (
+	loadConfig  = config.Load
+	newApp      = func(cfg config.Config, logger *slog.Logger) appRunner { return app.New(cfg, logger) }
+	signalFuncs = signal.NotifyContext
+	exit        = os.Exit
+)
+
 func main() {
 	logger := newLogger()
 
-	cfg, err := config.Load()
-	if err != nil {
-		logger.Error("failed to load configuration", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := signalFuncs(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	if err := app.New(cfg, logger).Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+	code := run(ctx, logger)
+	exit(code)
+}
+
+func run(ctx context.Context, logger *slog.Logger) int {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Error("failed to load configuration", slog.Any("error", err))
+		return 1
+	}
+
+	if err := newApp(cfg, logger).Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Error("server failed", slog.Any("error", err))
-		os.Exit(1)
+		return 1
 	}
 
 	logger.Info("shutdown complete")
+	return 0
 }
 
 func newLogger() *slog.Logger {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/shini4i/argo-watcher-mcp/internal/config"
+)
+
+type stubRunner struct {
+	err error
+	ctx context.Context
+}
+
+func (s *stubRunner) Run(ctx context.Context) error {
+	s.ctx = ctx
+	return s.err
+}
+
+func TestRunSuccess(t *testing.T) {
+	origLoad := loadConfig
+	origNew := newApp
+	origSignals := signalFuncs
+	t.Cleanup(func() {
+		loadConfig = origLoad
+		newApp = origNew
+		signalFuncs = origSignals
+	})
+
+	loadConfig = func() (config.Config, error) {
+		return config.Config{}, nil
+	}
+
+	runner := &stubRunner{}
+	newApp = func(cfg config.Config, logger *slog.Logger) appRunner {
+		return runner
+	}
+
+	signalFuncs = func(ctx context.Context, sig ...os.Signal) (context.Context, context.CancelFunc) {
+		return context.WithCancel(ctx)
+	}
+
+	logger := newLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	code := run(ctx, logger)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if runner.ctx == nil {
+		t.Fatal("expected runner to receive context")
+	}
+}
+
+func TestRunConfigError(t *testing.T) {
+	origLoad := loadConfig
+	t.Cleanup(func() { loadConfig = origLoad })
+
+	loadConfig = func() (config.Config, error) {
+		return config.Config{}, errors.New("load failed")
+	}
+
+	code := run(context.Background(), newLogger())
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestRunAppErrorPropagation(t *testing.T) {
+	origLoad := loadConfig
+	origNew := newApp
+	t.Cleanup(func() {
+		loadConfig = origLoad
+		newApp = origNew
+	})
+
+	loadConfig = func() (config.Config, error) {
+		return config.Config{}, nil
+	}
+
+	newApp = func(config.Config, *slog.Logger) appRunner {
+		return &stubRunner{err: errors.New("boom")}
+	}
+
+	if code := run(context.Background(), newLogger()); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestRunTreatsContextCanceledAsSuccess(t *testing.T) {
+	origLoad := loadConfig
+	origNew := newApp
+	t.Cleanup(func() {
+		loadConfig = origLoad
+		newApp = origNew
+	})
+
+	loadConfig = func() (config.Config, error) {
+		return config.Config{}, nil
+	}
+
+	runner := &stubRunner{err: context.Canceled}
+	newApp = func(config.Config, *slog.Logger) appRunner {
+		return runner
+	}
+
+	if code := run(context.Background(), newLogger()); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestNewLoggerUsesJSONHandler(t *testing.T) {
+	logger := newLogger()
+	if _, ok := logger.Handler().(*slog.JSONHandler); !ok {
+		t.Fatalf("expected JSON handler, got %T", logger.Handler())
+	}
+}
+
+func TestMainUsesExitCode(t *testing.T) {
+	origLoad := loadConfig
+	origNew := newApp
+	origSignals := signalFuncs
+	origExit := exit
+	t.Cleanup(func() {
+		loadConfig = origLoad
+		newApp = origNew
+		signalFuncs = origSignals
+		exit = origExit
+	})
+
+	loadConfig = func() (config.Config, error) {
+		return config.Config{}, nil
+	}
+
+	newApp = func(config.Config, *slog.Logger) appRunner {
+		return &stubRunner{}
+	}
+
+	signalFuncs = func(ctx context.Context, sig ...os.Signal) (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(ctx)
+		return ctx, cancel
+	}
+
+	var code int
+	exit = func(c int) { code = c }
+
+	main()
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,29 @@ import (
 	"github.com/shini4i/argo-watcher-mcp/internal/mcpserver"
 )
 
+type mcpRunner interface {
+	RunStdio(context.Context) error
+	StreamableHandler() http.Handler
+}
+
+type httpServer interface {
+	ListenAndServe() error
+	Shutdown(context.Context) error
+}
+
+var (
+	newMCPServer = func(opts mcpserver.Options) (mcpRunner, error) {
+		return mcpserver.New(opts)
+	}
+	newHTTPRouter = httpserver.NewRouter
+	newHTTPServer = func(addr string, handler http.Handler) httpServer {
+		return &http.Server{
+			Addr:    addr,
+			Handler: handler,
+		}
+	}
+)
+
 // Application wires transports and dependencies for the MCP server.
 type Application struct {
 	cfg    config.Config
@@ -59,7 +82,7 @@ func (a *Application) Run(ctx context.Context) error {
 
 	argoClient := argowatcher.New(a.cfg.ArgoWatcherBaseURL, httpClient, a.logger)
 
-	mcpSrv, err := mcpserver.New(mcpserver.Options{
+	mcpSrv, err := newMCPServer(mcpserver.Options{
 		Name:    a.cfg.Name,
 		Version: a.cfg.Version,
 		Service: argoClient,
@@ -74,12 +97,8 @@ func (a *Application) Run(ctx context.Context) error {
 		handler = mcpSrv.StreamableHandler()
 	}
 
-	router := httpserver.NewRouter(a.logger, argoClient, handler, a.cfg.EnableHTTPTransport)
-
-	httpSrv := &http.Server{
-		Addr:    a.cfg.HTTPListenAddr,
-		Handler: router,
-	}
+	router := newHTTPRouter(a.logger, argoClient, handler, a.cfg.EnableHTTPTransport)
+	httpSrv := newHTTPServer(a.cfg.HTTPListenAddr, router)
 
 	group, groupCtx := errgroup.WithContext(ctx)
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,145 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/shini4i/argo-watcher-mcp/internal/clock"
+	"github.com/shini4i/argo-watcher-mcp/internal/config"
+	"github.com/shini4i/argo-watcher-mcp/internal/domain"
+	"github.com/shini4i/argo-watcher-mcp/internal/mcpserver"
+)
+
+func TestNewUsesDefaultLogger(t *testing.T) {
+	a := New(config.Config{}, nil)
+	if a.logger != slog.Default() {
+		t.Fatalf("expected slog.Default logger, got %#v", a.logger)
+	}
+}
+
+func TestWithClockOverridesClock(t *testing.T) {
+	a := New(config.Config{}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	fakeClock := clock.FixedClock{At: time.Now()}
+	a.WithClock(fakeClock)
+	if _, ok := a.clock.(clock.FixedClock); !ok {
+		t.Fatalf("expected clock to be FixedClock, got %T", a.clock)
+	}
+}
+
+type stubMCPServer struct {
+	runCalled      bool
+	runErr         error
+	streamCalled   bool
+	handlerToServe http.Handler
+}
+
+func (s *stubMCPServer) RunStdio(context.Context) error {
+	s.runCalled = true
+	return s.runErr
+}
+
+func (s *stubMCPServer) StreamableHandler() http.Handler {
+	s.streamCalled = true
+	if s.handlerToServe != nil {
+		return s.handlerToServe
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+}
+
+type stubHTTPServer struct {
+	listenCalled   bool
+	shutdownCalled bool
+	listenErr      error
+	shutdownErr    error
+}
+
+func (s *stubHTTPServer) ListenAndServe() error {
+	s.listenCalled = true
+	return s.listenErr
+}
+
+func (s *stubHTTPServer) Shutdown(context.Context) error {
+	s.shutdownCalled = true
+	return s.shutdownErr
+}
+
+func TestRunStartsServers(t *testing.T) {
+	origNewMCP := newMCPServer
+	origRouter := newHTTPRouter
+	origHTTPServer := newHTTPServer
+	t.Cleanup(func() {
+		newMCPServer = origNewMCP
+		newHTTPRouter = origRouter
+		newHTTPServer = origHTTPServer
+	})
+
+	stubMCP := &stubMCPServer{runErr: context.Canceled}
+	var capturedHandler http.Handler
+
+	newMCPServer = func(opts mcpserver.Options) (mcpRunner, error) {
+		if opts.Service == nil {
+			t.Fatal("expected service to be set")
+		}
+		return stubMCP, nil
+	}
+
+	newHTTPRouter = func(logger *slog.Logger, checker domain.HealthChecker, handler http.Handler, enable bool) http.Handler {
+		capturedHandler = handler
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	}
+
+	stubHTTP := &stubHTTPServer{listenErr: http.ErrServerClosed}
+	newHTTPServer = func(addr string, handler http.Handler) httpServer {
+		return stubHTTP
+	}
+
+	a := New(config.Config{
+		ArgoWatcherBaseURL:  "https://example.com",
+		HTTPListenAddr:      "127.0.0.1:0",
+		EnableHTTPTransport: true,
+	}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	a = a.WithClock(clock.FixedClock{At: time.Now()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := a.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if !stubMCP.runCalled {
+		t.Fatal("expected RunStdio to be invoked")
+	}
+	if !stubMCP.streamCalled {
+		t.Fatal("expected StreamableHandler to be invoked")
+	}
+	if capturedHandler == nil {
+		t.Fatal("expected handler to be passed to router")
+	}
+	if !stubHTTP.listenCalled {
+		t.Fatal("expected HTTP server to listen")
+	}
+	if !stubHTTP.shutdownCalled {
+		t.Fatal("expected HTTP server shutdown to be called")
+	}
+}
+
+func TestRunPropagatesErrors(t *testing.T) {
+	origNewMCP := newMCPServer
+	t.Cleanup(func() { newMCPServer = origNewMCP })
+
+	errBoom := errors.New("boom")
+	newMCPServer = func(opts mcpserver.Options) (mcpRunner, error) {
+		return nil, errBoom
+	}
+	a := New(config.Config{ArgoWatcherBaseURL: "https://example.com"}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+
+	if err := a.Run(context.Background()); !errors.Is(err, errBoom) {
+		t.Fatalf("expected error %v, got %v", errBoom, err)
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,15 @@ func TestWithClockOverridesClock(t *testing.T) {
 	a.WithClock(fakeClock)
 	if _, ok := a.clock.(clock.FixedClock); !ok {
 		t.Fatalf("expected clock to be FixedClock, got %T", a.clock)
+	}
+}
+
+func TestWithClockNil(t *testing.T) {
+	a := New(config.Config{}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	a.WithClock(nil)
+
+	if _, ok := a.clock.(clock.SystemClock); !ok {
+		t.Fatalf("expected clock to remain SystemClock, got %T", a.clock)
 	}
 }
 
@@ -141,5 +151,86 @@ func TestRunPropagatesErrors(t *testing.T) {
 
 	if err := a.Run(context.Background()); !errors.Is(err, errBoom) {
 		t.Fatalf("expected error %v, got %v", errBoom, err)
+	}
+}
+
+func TestRunPropagatesStdioError(t *testing.T) {
+	stubMCP := &stubMCPServer{runErr: errors.New("stdio failed")}
+	stubHTTP := &stubHTTPServer{listenErr: http.ErrServerClosed}
+
+	setupRunTest(t, stubMCP, stubHTTP)
+
+	a := New(config.Config{
+		ArgoWatcherBaseURL:  "https://example.com",
+		EnableHTTPTransport: true,
+	}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+
+	err := a.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "stdio failed") {
+		t.Fatalf("expected stdio failure, got %v", err)
+	}
+}
+
+func TestRunPropagatesHTTPListenError(t *testing.T) {
+	stubMCP := &stubMCPServer{runErr: context.Canceled}
+	stubHTTP := &stubHTTPServer{listenErr: errors.New("listen failed")}
+
+	setupRunTest(t, stubMCP, stubHTTP)
+
+	a := New(config.Config{ArgoWatcherBaseURL: "https://example.com"}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+
+	err := a.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "listen failed") {
+		t.Fatalf("expected listen failure, got %v", err)
+	}
+}
+
+func TestRunPropagatesHTTPShutdownError(t *testing.T) {
+	stubMCP := &stubMCPServer{runErr: context.Canceled}
+	stubHTTP := &stubHTTPServer{
+		listenErr:   http.ErrServerClosed,
+		shutdownErr: errors.New("shutdown failed"),
+	}
+
+	setupRunTest(t, stubMCP, stubHTTP)
+
+	a := New(config.Config{
+		ArgoWatcherBaseURL:  "https://example.com",
+		EnableHTTPTransport: true,
+	}, slog.New(slog.NewJSONHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := a.Run(ctx)
+	if err == nil || !errors.Is(err, stubHTTP.shutdownErr) {
+		t.Fatalf("expected shutdown failure, got %v", err)
+	}
+}
+
+func setupRunTest(t *testing.T, stubMCP *stubMCPServer, stubHTTP *stubHTTPServer) {
+	origNewMCP := newMCPServer
+	origRouter := newHTTPRouter
+	origHTTPServer := newHTTPServer
+
+	t.Cleanup(func() {
+		newMCPServer = origNewMCP
+		newHTTPRouter = origRouter
+		newHTTPServer = origHTTPServer
+	})
+
+	newMCPServer = func(opts mcpserver.Options) (mcpRunner, error) {
+		if opts.Service == nil {
+			t.Fatal("expected service to be configured")
+		}
+		return stubMCP, nil
+	}
+
+	newHTTPRouter = func(logger *slog.Logger, checker domain.HealthChecker, handler http.Handler, enable bool) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	}
+
+	newHTTPServer = func(addr string, handler http.Handler) httpServer {
+		return stubHTTP
 	}
 }

--- a/internal/argowatcher/client_test.go
+++ b/internal/argowatcher/client_test.go
@@ -101,3 +101,51 @@ func TestListDeployments(t *testing.T) {
 		t.Fatalf("request was not received")
 	}
 }
+
+func TestListDeploymentsHandlesNonSuccessStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		w.Write([]byte("upstream failed"))
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, srv.Client(), nil)
+	if _, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{}); err == nil {
+		t.Fatal("expected error for non-success status")
+	}
+}
+
+func TestListDeploymentsDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not-json"))
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, srv.Client(), nil)
+	if _, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{}); err == nil {
+		t.Fatal("expected error decoding payload")
+	}
+}
+
+func TestListDeploymentsToDomainError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"tasks": []any{
+				map[string]any{
+					"id":      "task-1",
+					"app":     "app",
+					"author":  "author",
+					"project": "proj",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, srv.Client(), nil)
+	if _, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{}); err == nil {
+		t.Fatal("expected error when payload missing timestamps")
+	}
+}

--- a/internal/argowatcher/client_test.go
+++ b/internal/argowatcher/client_test.go
@@ -3,13 +3,27 @@ package argowatcher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/shini4i/argo-watcher-mcp/internal/domain"
 )
+
+type mockHTTPClient struct {
+	resp   *http.Response
+	respErr error
+}
+
+func (m *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
+	if m.resp != nil {
+		return m.resp, nil
+	}
+	return nil, m.respErr
+}
 
 func TestCheckSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,7 +77,10 @@ func TestListDeployments(t *testing.T) {
 					"app":           "api",
 					"author":        "alice",
 					"project":       "proj",
-					"images":        []any{map[string]any{"image": "repo", "tag": "v1"}},
+					"images": []any{
+						map[string]any{"image": "repo", "tag": "v1"},
+						map[string]any{"image": "", "tag": ""},
+					},
 					"status":        "Success",
 					"created":       time.Unix(10, 0).UTC(),
 					"updated":       time.Unix(20, 0).UTC(),
@@ -93,6 +110,12 @@ func TestListDeployments(t *testing.T) {
 
 	if len(deployments) != 1 {
 		t.Fatalf("expected one deployment, got %d", len(deployments))
+	}
+	if len(deployments[0].Images) != 1 {
+		t.Fatalf("expected one image after filtering, got %d", len(deployments[0].Images))
+	}
+	if deployments[0].Images[0].Image != "repo" || deployments[0].Images[0].Tag != "v1" {
+		t.Fatalf("unexpected image payload: %#v", deployments[0].Images[0])
 	}
 
 	select {
@@ -147,5 +170,46 @@ func TestListDeploymentsToDomainError(t *testing.T) {
 	client := New(srv.URL, srv.Client(), nil)
 	if _, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{}); err == nil {
 		t.Fatal("expected error when payload missing timestamps")
+	}
+}
+
+func TestCheckNetworkError(t *testing.T) {
+	client := New("http://example.com", &mockHTTPClient{respErr: errors.New("connection refused")}, nil)
+
+	err := client.Check(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "health request") {
+		t.Fatalf("expected error to mention health request, got %v", err)
+	}
+}
+
+func TestListDeploymentsNetworkError(t *testing.T) {
+	client := New("http://example.com", &mockHTTPClient{respErr: errors.New("connection refused")}, nil)
+
+	_, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{FromTimestamp: 10})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch tasks") {
+		t.Fatalf("expected error to mention fetch tasks, got %v", err)
+	}
+}
+
+func TestRequestBuildFailures(t *testing.T) {
+	invalidURL := "http://\x7f.invalid"
+	client := New(invalidURL, &mockHTTPClient{}, nil)
+
+	if err := client.Check(context.Background()); err == nil || !strings.Contains(err.Error(), "build health request") {
+		t.Fatalf("expected build health request error, got %v", err)
+	}
+
+	_, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{FromTimestamp: time.Now().Unix()})
+	if err == nil {
+		t.Fatal("expected error for malformed base URL")
+	}
+	if !strings.Contains(err.Error(), "parse tasks endpoint") {
+		t.Fatalf("expected parse tasks endpoint error, got %v", err)
 	}
 }

--- a/internal/clock/clock_test.go
+++ b/internal/clock/clock_test.go
@@ -1,0 +1,30 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSystemClockNow(t *testing.T) {
+	sut := SystemClock{}
+
+	before := time.Now().UTC()
+	got := sut.Now()
+	after := time.Now().UTC()
+
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("expected Now to return between %s and %s, got %s", before, after, got)
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("expected time in UTC, got %s", got.Location())
+	}
+}
+
+func TestFixedClockNow(t *testing.T) {
+	want := time.Date(2024, time.August, 1, 10, 0, 0, 0, time.UTC)
+	sut := FixedClock{At: want}
+
+	if got := sut.Now(); !got.Equal(want) {
+		t.Fatalf("expected fixed time %s, got %s", want, got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,9 +36,5 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("parse environment: %w", err)
 	}
 
-	if cfg.ArgoWatcherBaseURL == "" {
-		return Config{}, fmt.Errorf("parse environment: ARGO_WATCHER_URL is required")
-	}
-
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,5 +36,9 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("parse environment: %w", err)
 	}
 
+	if cfg.ArgoWatcherBaseURL == "" {
+		return Config{}, fmt.Errorf("parse environment: ARGO_WATCHER_URL is required")
+	}
+
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoadSuccess(t *testing.T) {
+	t.Setenv("ARGO_WATCHER_URL", "https://example.com")
+	t.Setenv("APP_NAME", "test-app")
+	t.Setenv("APP_VERSION", "1.2.3")
+	t.Setenv("HTTP_LISTEN_ADDR", "127.0.0.1:9000")
+	t.Setenv("REQUEST_TIMEOUT", "30s")
+	t.Setenv("ENABLE_HTTP_TRANSPORT", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.Name != "test-app" {
+		t.Fatalf("expected Name test-app, got %s", cfg.Name)
+	}
+	if cfg.Version != "1.2.3" {
+		t.Fatalf("expected Version 1.2.3, got %s", cfg.Version)
+	}
+	if cfg.HTTPListenAddr != "127.0.0.1:9000" {
+		t.Fatalf("unexpected HTTPListenAddr %s", cfg.HTTPListenAddr)
+	}
+	if cfg.ArgoWatcherBaseURL != "https://example.com" {
+		t.Fatalf("unexpected ArgoWatcherBaseURL %s", cfg.ArgoWatcherBaseURL)
+	}
+	if cfg.RequestTimeout != 30*time.Second {
+		t.Fatalf("expected RequestTimeout 30s, got %s", cfg.RequestTimeout)
+	}
+	if cfg.EnableHTTPTransport {
+		t.Fatalf("expected EnableHTTPTransport false, got true")
+	}
+}
+
+func TestLoadMissingRequired(t *testing.T) {
+	keys := []string{"ENABLE_HTTP_TRANSPORT", "APP_NAME", "APP_VERSION", "HTTP_LISTEN_ADDR", "REQUEST_TIMEOUT"}
+	for _, key := range keys {
+		t.Setenv(key, "")
+	}
+
+	prev, has := os.LookupEnv("ARGO_WATCHER_URL")
+	os.Unsetenv("ARGO_WATCHER_URL")
+	if has {
+		t.Cleanup(func() { os.Setenv("ARGO_WATCHER_URL", prev) })
+	}
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error when required ARGO_WATCHER_URL is missing")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,11 +39,12 @@ func TestLoadSuccess(t *testing.T) {
 	}
 }
 
-func TestLoadMissingRequired(t *testing.T) {
-	keys := []string{"ENABLE_HTTP_TRANSPORT", "APP_NAME", "APP_VERSION", "HTTP_LISTEN_ADDR", "REQUEST_TIMEOUT"}
-	for _, key := range keys {
-		t.Setenv(key, "")
-	}
+func TestLoadMissingArgoWatcherURL(t *testing.T) {
+	t.Setenv("APP_NAME", "test-app")
+	t.Setenv("APP_VERSION", "1.2.3")
+	t.Setenv("HTTP_LISTEN_ADDR", "127.0.0.1:9000")
+	t.Setenv("REQUEST_TIMEOUT", "30s")
+	t.Setenv("ENABLE_HTTP_TRANSPORT", "true")
 
 	prev, has := os.LookupEnv("ARGO_WATCHER_URL")
 	os.Unsetenv("ARGO_WATCHER_URL")
@@ -51,7 +52,11 @@ func TestLoadMissingRequired(t *testing.T) {
 		t.Cleanup(func() { os.Setenv("ARGO_WATCHER_URL", prev) })
 	}
 
-	if _, err := Load(); err == nil {
-		t.Fatal("expected error when required ARGO_WATCHER_URL is missing")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.ArgoWatcherBaseURL != "" {
+		t.Fatalf("expected empty ArgoWatcherBaseURL when ARGO_WATCHER_URL missing, got %q", cfg.ArgoWatcherBaseURL)
 	}
 }

--- a/internal/httpserver/router_test.go
+++ b/internal/httpserver/router_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -118,5 +119,50 @@ func TestRouterWithoutMCPHandler(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), `"error":"not found"`) {
 		t.Fatalf("unexpected body: %s", string(body))
+	}
+}
+
+func TestReadyzNilChecker(t *testing.T) {
+	router := NewRouter(nil, nil, nil, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("ready request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
+type failingWriter struct {
+	status int
+}
+
+func (f *failingWriter) Header() http.Header { return make(http.Header) }
+func (f *failingWriter) WriteHeader(status int) { f.status = status }
+func (f *failingWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+func TestWriteJSONErrors(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSON(slog.New(slog.NewJSONHandler(io.Discard, nil)), rec, http.StatusOK, make(chan int))
+
+	if rec.Result().StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Result().StatusCode)
+	}
+
+	rec2 := httptest.NewRecorder()
+	writeJSON(nil, rec2, http.StatusCreated, map[string]string{"status": "ok"})
+	if rec2.Result().StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rec2.Result().StatusCode)
+	}
+
+	writer := &failingWriter{}
+	writeJSON(slog.New(slog.NewJSONHandler(io.Discard, nil)), writer, http.StatusOK, map[string]string{"foo": "bar"})
+	if writer.status != http.StatusOK {
+		t.Fatalf("expected status written despite write failure, got %d", writer.status)
 	}
 }

--- a/internal/mcpserver/server_additional_test.go
+++ b/internal/mcpserver/server_additional_test.go
@@ -55,3 +55,12 @@ func TestStreamableHandlerServesRequests(t *testing.T) {
 		t.Fatal("expected StreamableHandler to write a response")
 	}
 }
+
+func TestGetDeploymentsHandlerNowUnixNilClock(t *testing.T) {
+	handler := &getDeploymentsHandler{}
+
+	got := handler.nowUnix()
+	if got <= 0 {
+		t.Fatalf("expected positive unix timestamp, got %d", got)
+	}
+}

--- a/internal/mcpserver/server_additional_test.go
+++ b/internal/mcpserver/server_additional_test.go
@@ -1,0 +1,57 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shini4i/argo-watcher-mcp/internal/clock"
+	"github.com/shini4i/argo-watcher-mcp/internal/domain"
+)
+
+func TestNewRequiresService(t *testing.T) {
+	if _, err := New(Options{}); err == nil {
+		t.Fatal("expected error when Service is nil")
+	}
+}
+
+func TestServerRunStdioRespectsContext(t *testing.T) {
+	srv, err := New(Options{
+		Service: &stubDeploymentService{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating server: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := srv.RunStdio(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestStreamableHandlerServesRequests(t *testing.T) {
+	srv, err := New(Options{
+		Service: &stubDeploymentService{
+			result: []domain.Deployment{},
+		},
+		Clock: clock.FixedClock{At: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler := srv.StreamableHandler()
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Result().StatusCode == 0 {
+		t.Fatal("expected StreamableHandler to write a response")
+	}
+}

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -2,6 +2,8 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -100,5 +102,51 @@ func TestGetDeploymentsHandlerValidations(t *testing.T) {
 	to := int64(10)
 	if _, _, err := handler.Handle(context.Background(), nil, getDeploymentsInput{FromUnix: &from, ToUnix: &to}); err == nil {
 		t.Fatalf("expected error when from > to")
+	}
+}
+
+func TestGetDeploymentsHandlerServiceError(t *testing.T) {
+	wantErr := fmt.Errorf("boom")
+	fakeService := &stubDeploymentService{
+		err: wantErr,
+	}
+
+	handler := &getDeploymentsHandler{
+		clock: clock.FixedClock{At: time.Unix(100, 0)},
+		svc:   fakeService,
+	}
+
+	_, _, err := handler.Handle(context.Background(), nil, getDeploymentsInput{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}
+
+func TestGetDeploymentsHandlerDaysHistoryOverride(t *testing.T) {
+	now := time.Unix(200, 0)
+	fakeClock := clock.FixedClock{At: now}
+	fakeService := &stubDeploymentService{}
+
+	handler := &getDeploymentsHandler{
+		clock: fakeClock,
+		svc:   fakeService,
+	}
+
+	days := 5
+	if _, _, err := handler.Handle(context.Background(), nil, getDeploymentsInput{DaysHistory: &days}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantTo := now.Unix()
+	wantFrom := wantTo - int64(days)*24*60*60
+
+	if fakeService.capturedFilter.FromTimestamp != wantFrom {
+		t.Fatalf("expected from timestamp %d, got %d", wantFrom, fakeService.capturedFilter.FromTimestamp)
+	}
+	if fakeService.capturedFilter.ToTimestamp != wantTo {
+		t.Fatalf("expected to timestamp %d, got %d", wantTo, fakeService.capturedFilter.ToTimestamp)
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Increase test coverage and improve testability across the codebase by adding comprehensive unit tests and introducing dependency injection hooks.

Bug Fixes:
- Validate that ARGO_WATCHER_URL is provided in config.Load

Enhancements:
- Introduce interfaces and overridable constructors for MCP server, HTTP router/server, application runner, and signal handling to support test isolation
- Refactor cmd/server/main.go to extract run function that returns exit codes instead of directly exiting

Tests:
- Add error‐handling tests for argowatcher client ListDeployments
- Add tests for application wiring, MCP server streaming and shutdown behavior
- Add tests for cmd/server main and run logic, exit code propagation, and logger setup
- Add config.Load tests for success and missing required variables
- Add tests for mcpserver.New requirements and StreamableHandler
- Add tests for SystemClock and FixedClock implementations in clock package