### PR TITLE
feat(health)!: follow argo-watcher's liveness/readiness split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ Breaking entries are marked below.
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** the readiness check now probes argo-watcher's `/livez` and
+  `/readyz` instead of `/healthz`, which
+  [its probe split](https://github.com/shini4i/argo-watcher/pull/535) removes.
+  Those endpoints are unreleased upstream: against v0.14.0 and older, `/readyz`
+  here returns `503` with `no probe payload`, so do not wire a readiness probe to
+  this server until its argo-watcher serves them. The MCP tools are unaffected and
+  keep working against v0.13.0+. A pre-split argo-watcher answers `/livez` from
+  the catch-all serving its Web UI, so the probe response is recognised by its
+  JSON payload rather than its status code — an HTML shell at `200` is refused
+  rather than read as healthy.
+- **Breaking:** `/readyz` stays `200` when argo-watcher answers but reports itself
+  unready — state backend down, or shutting down — and names the verdict in the
+  body as `argo_watcher` and `argo_watcher_reason` instead. It previously returned
+  `503`. Every replica shares one argo-watcher, so failing readiness on its state
+  backend withdrew all of them at once and took `get_reachability`, the tool that
+  explains the outage, out of reach with them. `503` is now reserved for an
+  argo-watcher whose process does not answer at all. Alerts that watched this
+  endpoint for a state-backend outage should watch `get_reachability` or
+  argo-watcher's own metrics instead.
+- **Breaking:** `argo_watcher_reachable` follows the same line: it now reads `1`
+  for an argo-watcher that answers while reporting itself unready, where it
+  previously read `0`.
+
 ## [0.3.0] - 2026-07-30
 
 The server is now written in Go, and covers argo-watcher's read-only API rather

--- a/README.md
+++ b/README.md
@@ -59,10 +59,15 @@ to apply when it did not.
 | `is_rollback` / `rollback_target_id` | v0.11.0 |
 | `limit` / `offset` | v0.12.0 |
 | `get_reachability` | v0.13.0 |
+| `/readyz` (this server's own readiness check) | unreleased |
 
-v0.12.0+ is recommended. `get_reachability` needs `/api/v1/reachability`, which
-has no stable release yet (only `v0.13.0-pre.20260726`), so it fails against
-current stable upstream.
+v0.13.0+ is recommended; v0.14.0 is the current stable upstream release.
+
+This server's readiness check requires argo-watcher's `/livez` and `/readyz`,
+which arrive with [the probe split](https://github.com/shini4i/argo-watcher/pull/535)
+and are unreleased. Against v0.14.0 and older it reports `503` with
+`no probe payload`, so give this server an upstream that serves them before
+wiring a readiness probe to it. Every MCP tool works against v0.13.0+ regardless.
 
 ## Prerequisites
 
@@ -129,12 +134,36 @@ current stable upstream.
 | `APP_NAME` | `argo-watcher-mcp` | Metadata surfaced via MCP implementation info. |
 | `APP_VERSION` | build-stamped (`local` otherwise) | Version surfaced via MCP implementation info. Releases link it in; set this only to override. |
 
+### Health endpoints
+
+The HTTP transport serves two unauthenticated probe endpoints:
+
+| Endpoint | Reports | Use as |
+|----------|---------|--------|
+| `/healthz` | This process is serving; checks nothing else | Liveness probe |
+| `/readyz` | This process is serving **and** argo-watcher answers | Readiness probe |
+
+`/readyz` deliberately stays `200` when argo-watcher answers but reports itself
+unready — its state backend is down, or it is shutting down. Every replica of this
+server shares one argo-watcher, so failing readiness there would withdraw all of
+them at once and take `get_reachability`, the tool that names the cause, out of
+reach with them. That verdict is reported in the body instead:
+
+```json
+{"status":"ready","argo_watcher":"not_ready","argo_watcher_reason":"state backend unreachable"}
+```
+
+Alert on `get_reachability` or on argo-watcher's own metrics for that condition.
+`/readyz` returns `503` only when argo-watcher's process does not answer at all —
+including against an upstream too old to serve `/livez`, per
+[Required argo-watcher version](#required-argo-watcher-version).
+
 ### Telemetry & Metrics
 
 When telemetry is enabled, the HTTP transport exposes Prometheus metrics at `/metrics`. Key series:
 
 - `argo_watcher_mcp_requests_total{result="success|invalid|failed"}` – MCP tool call counter partitioned by result label; filter by `result` to obtain invalid or failed counts.
-- `argo_watcher_reachable` – gauge reporting downstream reachability (`1` when Argo Watcher responded successfully, `0` otherwise).
+- `argo_watcher_reachable` – gauge reporting downstream reachability (`1` when argo-watcher answered, `0` otherwise). It tracks reachability, not health: an argo-watcher whose readiness probe reports it unready still reads `1`.
 - Standard Go runtime (`go_*`) and process metrics are registered on the Prometheus endpoint to aid capacity monitoring.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ wiring a readiness probe to it. Every MCP tool works against v0.13.0+ regardless
 | `ARGO_WATCHER_URL` | _none_ (required) | Base URL of the upstream argo-watcher service. |
 | `HTTP_LISTEN_ADDR` | `:8000` | Address for the HTTP/SSE transport. |
 | `TRANSPORT_MODE` | `stdio` | Selects transport: `stdio` for CLI usage or `http` for SSE over HTTP. |
-| `REQUEST_TIMEOUT` | `15s` | HTTP timeout for downstream argo-watcher requests. |
+| `REQUEST_TIMEOUT` | `15s` | HTTP timeout for downstream argo-watcher requests. Does not apply to the probe endpoints, which are bounded separately — see [Health endpoints](#health-endpoints). |
 | `OTEL_ENABLED` | `true` | Enables OpenTelemetry instrumentation; set to `false` to disable all telemetry exports. |
 | `OTEL_SERVICE_NAME` | inherits `APP_NAME` | Overrides the OpenTelemetry `service.name` resource attribute reported by the server. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _none_ | Optional OTLP gRPC endpoint (`host:port`) used for exporting metrics and traces. |
@@ -157,6 +157,10 @@ Alert on `get_reachability` or on argo-watcher's own metrics for that condition.
 `/readyz` returns `503` only when argo-watcher's process does not answer at all —
 including against an upstream too old to serve `/livez`, per
 [Required argo-watcher version](#required-argo-watcher-version).
+
+Each upstream probe is bounded at 2s rather than by `REQUEST_TIMEOUT`, so this
+endpoint answers inside a normal probe deadline even when argo-watcher's readiness
+handler hangs on its state backend.
 
 ### Telemetry & Metrics
 

--- a/internal/argowatcher/client.go
+++ b/internal/argowatcher/client.go
@@ -123,11 +123,15 @@ func (c *Client) upstreamReadiness(ctx context.Context) domain.UpstreamHealth {
 		return domain.UpstreamHealth{Reason: "readiness probe unreachable"}
 	}
 
+	verdict, ok := parseProbeVerdict(body)
+	if !ok {
+		return domain.UpstreamHealth{Reason: fmt.Sprintf("status %d carried no probe payload", status)}
+	}
+
 	if isSuccess(status) {
 		return domain.UpstreamHealth{Ready: true}
 	}
 
-	verdict, _ := parseProbeVerdict(body)
 	return domain.UpstreamHealth{Reason: verdictReason(status, verdict)}
 }
 

--- a/internal/argowatcher/client.go
+++ b/internal/argowatcher/client.go
@@ -79,6 +79,13 @@ const (
 
 const probeBodyLimit = 4 << 10
 
+// probeTimeout bounds each probe independently of REQUEST_TIMEOUT. Argo Watcher's
+// readiness handler pings its state backend, which a hung database blocks, and two
+// sequential probes on the shared 15s client timeout would stall this server's own
+// /readyz past any sane probe deadline — failing it for a slow dependency, which
+// is the outcome the liveness gate exists to avoid.
+const probeTimeout = 2 * time.Second
+
 // probeVerdict is the payload both probe endpoints answer with.
 type probeVerdict struct {
 	Status string `json:"status"`
@@ -137,6 +144,9 @@ func (c *Client) upstreamReadiness(ctx context.Context) domain.UpstreamHealth {
 
 // probe issues a GET against one of Argo Watcher's probe endpoints.
 func (c *Client) probe(ctx context.Context, path string) (int, []byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return 0, nil, fmt.Errorf("build probe request for %s: %w", path, err)

--- a/internal/argowatcher/client.go
+++ b/internal/argowatcher/client.go
@@ -70,35 +70,116 @@ func New(baseURL string, client HTTPClient, logger *slog.Logger, options ...Opti
 	return c
 }
 
-// Check verifies the downstream service is responding on /healthz.
+// Argo Watcher's probe endpoints, introduced by its probe split
+// (shini4i/argo-watcher#535). Releases predating it serve neither.
+const (
+	livenessPath  = "/livez"
+	readinessPath = "/readyz"
+)
+
+const probeBodyLimit = 4 << 10
+
+// probeVerdict is the payload both probe endpoints answer with.
+type probeVerdict struct {
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
+
+// Check reports whether Argo Watcher answers, and what its own readiness probe
+// says. The error covers liveness only — see domain.HealthChecker.
 //
-// Note this probes only Argo Watcher's own state backend; it says nothing about
-// whether Argo Watcher can reach ArgoCD. GetReachability answers that.
-func (c *Client) Check(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/healthz", nil)
+// Neither probe covers whether Argo Watcher can reach ArgoCD; GetReachability
+// answers that.
+func (c *Client) Check(ctx context.Context) (domain.UpstreamHealth, error) {
+	status, body, err := c.probe(ctx, livenessPath)
 	if err != nil {
 		c.metrics.ReportUnreachable()
-		return fmt.Errorf("build health request: %w", err)
+		return domain.UpstreamHealth{}, err
+	}
+
+	if !isSuccess(status) {
+		c.metrics.ReportUnreachable()
+		verdict, _ := parseProbeVerdict(body)
+		return domain.UpstreamHealth{}, fmt.Errorf("probe %s: %s", livenessPath, verdictReason(status, verdict))
+	}
+
+	if _, ok := parseProbeVerdict(body); !ok {
+		c.metrics.ReportUnreachable()
+		return domain.UpstreamHealth{}, fmt.Errorf("probe %s: status %d carried no probe payload; Argo Watcher predating the probe split does not serve this endpoint", livenessPath, status)
+	}
+
+	c.metrics.ReportReachable()
+	return c.upstreamReadiness(ctx), nil
+}
+
+// upstreamReadiness asks Argo Watcher's readiness probe for its verdict. A
+// verdict it could not obtain is reported unready, never ready.
+func (c *Client) upstreamReadiness(ctx context.Context) domain.UpstreamHealth {
+	status, body, err := c.probe(ctx, readinessPath)
+	if err != nil {
+		// The detail names Argo Watcher's host and port, which this server reports
+		// on an unauthenticated endpoint, so it stays in the log.
+		c.logger.Warn("argo-watcher readiness probe failed", slog.Any("error", err))
+		return domain.UpstreamHealth{Reason: "readiness probe unreachable"}
+	}
+
+	if isSuccess(status) {
+		return domain.UpstreamHealth{Ready: true}
+	}
+
+	verdict, _ := parseProbeVerdict(body)
+	return domain.UpstreamHealth{Reason: verdictReason(status, verdict)}
+}
+
+// probe issues a GET against one of Argo Watcher's probe endpoints.
+func (c *Client) probe(ctx context.Context, path string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("build probe request for %s: %w", path, err)
 	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		c.metrics.ReportUnreachable()
-		return fmt.Errorf("health request: %w", err)
+		return 0, nil, fmt.Errorf("probe %s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		c.metrics.ReportUnreachable()
-		return fmt.Errorf("health request: unexpected status %d", resp.StatusCode)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, probeBodyLimit))
+	if err != nil {
+		return 0, nil, fmt.Errorf("read %s response: %w", path, err)
 	}
 
-	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-		c.metrics.ReportUnreachable()
-		return fmt.Errorf("drain response body: %w", err)
+	return resp.StatusCode, body, nil
+}
+
+// parseProbeVerdict decodes a probe payload, reporting false for a body that is
+// not one — the Web UI shell, or whatever else answers a URL that is not an Argo
+// Watcher.
+func parseProbeVerdict(body []byte) (probeVerdict, bool) {
+	var verdict probeVerdict
+	if err := json.Unmarshal(body, &verdict); err != nil {
+		return probeVerdict{}, false
 	}
-	c.metrics.ReportReachable()
-	return nil
+
+	if strings.TrimSpace(verdict.Status) == "" {
+		return probeVerdict{}, false
+	}
+
+	return verdict, true
+}
+
+// verdictReason prefers Argo Watcher's own explanation, falling back to the
+// status code when it supplies none.
+func verdictReason(status int, verdict probeVerdict) string {
+	if reason := strings.TrimSpace(verdict.Reason); reason != "" {
+		return reason
+	}
+
+	return fmt.Sprintf("status %d", status)
+}
+
+func isSuccess(status int) bool {
+	return status >= 200 && status < 300
 }
 
 // getJSON issues a GET against endpoint and decodes the JSON body into out.

--- a/internal/argowatcher/client_test.go
+++ b/internal/argowatcher/client_test.go
@@ -225,19 +225,34 @@ func TestCheckNoProbeEndpoint(t *testing.T) {
 	}
 }
 
-// An unobserved verdict must not be reported as ready.
-func TestCheckReadinessProbeFailureIsNotReady(t *testing.T) {
-	_, client, _ := newProbeServer(t, map[string]probeResponse{
-		"/livez":  {status: http.StatusOK, body: `{"status":"up"}`},
-		"/readyz": {status: http.StatusInternalServerError, body: "boom"},
-	})
+// An unobserved verdict must not be reported as ready, whatever status carried it.
+func TestCheckReadinessWithoutAProbePayloadIsNotReady(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "server error", status: http.StatusInternalServerError, body: "boom"},
+		{name: "2xx web UI shell", status: http.StatusOK, body: "<!doctype html><title>Argo Watcher</title>"},
+		{name: "2xx empty body", status: http.StatusOK, body: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, client, _ := newProbeServer(t, map[string]probeResponse{
+				"/livez":  {status: http.StatusOK, body: `{"status":"up"}`},
+				"/readyz": {status: tc.status, body: tc.body},
+			})
 
-	health, err := client.Check(context.Background())
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if health.Ready || health.Reason != "status 500" {
-		t.Fatalf("expected unready with a status fallback reason, got %+v", health)
+			health, err := client.Check(context.Background())
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if health.Ready {
+				t.Fatalf("expected unready when no verdict was obtained, got %+v", health)
+			}
+			if health.Reason != fmt.Sprintf("status %d carried no probe payload", tc.status) {
+				t.Fatalf("expected the reason to name the missing payload, got %q", health.Reason)
+			}
+		})
 	}
 }
 

--- a/internal/argowatcher/client_test.go
+++ b/internal/argowatcher/client_test.go
@@ -256,6 +256,44 @@ func TestCheckReadinessWithoutAProbePayloadIsNotReady(t *testing.T) {
 	}
 }
 
+// A hung Argo Watcher must not stall this server's own readiness endpoint past a
+// kubelet probe deadline. Its readiness handler pings the state backend, so a hung
+// database is what produces this.
+func TestCheckBoundsEachProbe(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/livez" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"up"}`))
+			return
+		}
+
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := New(srv.URL, srv.Client(), slog.New(slog.NewJSONHandler(io.Discard, nil)))
+
+	start := time.Now()
+	health, err := client.Check(context.Background())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("a hung readiness probe must not fail the check, got %v", err)
+	}
+	if health.Ready {
+		t.Fatal("expected unready when the readiness verdict timed out")
+	}
+	if elapsed > 2*probeTimeout {
+		t.Fatalf("expected the probe to be bounded near %s, took %s", probeTimeout, elapsed)
+	}
+}
+
 // The reason on a transport failure must stay bounded: this server serves it on
 // an unauthenticated endpoint, and the Go error names Argo Watcher's host.
 func TestCheckReadinessTransportFailureReasonIsBounded(t *testing.T) {

--- a/internal/argowatcher/client_test.go
+++ b/internal/argowatcher/client_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -38,6 +40,23 @@ func (m *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
 	return nil, m.respErr
 }
 
+// sequencedHTTPClient serves responses in order, then fails every later call.
+type sequencedHTTPClient struct {
+	responses []*http.Response
+	err       error
+	calls     int
+}
+
+func (s *sequencedHTTPClient) Do(*http.Request) (*http.Response, error) {
+	defer func() { s.calls++ }()
+
+	if s.calls < len(s.responses) {
+		return s.responses[s.calls], nil
+	}
+
+	return nil, s.err
+}
+
 type trackingReachability struct {
 	reachable   int
 	unreachable int
@@ -51,38 +70,203 @@ func (t *trackingReachability) ReportUnreachable() {
 	t.unreachable++
 }
 
-func TestCheckSuccess(t *testing.T) {
+// probeServer answers Argo Watcher's probe endpoints from a table and records
+// the paths asked for. An absent path answers 404.
+type probeServer struct {
+	responses map[string]probeResponse
+	requested []string
+}
+
+type probeResponse struct {
+	status int
+	body   string
+}
+
+func newProbeServer(t *testing.T, responses map[string]probeResponse) (*probeServer, *Client, *trackingReachability) {
+	t.Helper()
+
+	probes := &probeServer{responses: responses}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/healthz" {
-			t.Errorf("unexpected path %s", r.URL.Path)
+		probes.requested = append(probes.requested, r.URL.Path)
+
+		response, known := probes.responses[r.URL.Path]
+		if !known {
+			w.WriteHeader(http.StatusNotFound)
+			return
 		}
-		w.WriteHeader(http.StatusOK)
+
+		w.WriteHeader(response.status)
+		if response.body != "" {
+			_, _ = w.Write([]byte(response.body))
+		}
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	metrics := &trackingReachability{}
-	client := New(srv.URL, srv.Client(), nil, WithReachabilityMetrics(metrics))
-	if err := client.Check(context.Background()); err != nil {
+	return probes, New(srv.URL, srv.Client(), nil, WithReachabilityMetrics(metrics)), metrics
+}
+
+func TestCheckSuccess(t *testing.T) {
+	probes, client, metrics := newProbeServer(t, map[string]probeResponse{
+		"/livez":  {status: http.StatusOK, body: `{"status":"up"}`},
+		"/readyz": {status: http.StatusOK, body: `{"status":"up"}`},
+	})
+
+	health, err := client.Check(context.Background())
+	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+	if !health.Ready {
+		t.Fatalf("expected upstream reported ready, got %+v", health)
+	}
+	if health.Reason != "" {
+		t.Fatalf("expected no reason on a ready upstream, got %q", health.Reason)
+	}
+	if got := strings.Join(probes.requested, ","); got != "/livez,/readyz" {
+		t.Fatalf("expected /livez then /readyz, got %s", got)
 	}
 	if metrics.reachable != 1 || metrics.unreachable != 0 {
 		t.Fatalf("expected reachability metrics reachable=1 unreachable=0, got %d/%d", metrics.reachable, metrics.unreachable)
 	}
 }
 
-func TestCheckFailure(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-	}))
-	defer srv.Close()
+func TestCheckUnreadyUpstreamStillPasses(t *testing.T) {
+	_, client, metrics := newProbeServer(t, map[string]probeResponse{
+		"/livez":  {status: http.StatusOK, body: `{"status":"up"}`},
+		"/readyz": {status: http.StatusServiceUnavailable, body: `{"status":"down","reason":"state backend unreachable"}`},
+	})
 
-	metrics := &trackingReachability{}
-	client := New(srv.URL, srv.Client(), nil, WithReachabilityMetrics(metrics))
-	if err := client.Check(context.Background()); err == nil {
-		t.Fatalf("expected error, got nil")
+	health, err := client.Check(context.Background())
+	if err != nil {
+		t.Fatalf("an unready upstream must not fail the check, got %v", err)
+	}
+	if health.Ready {
+		t.Fatal("expected upstream reported unready")
+	}
+	if health.Reason != "state backend unreachable" {
+		t.Fatalf("expected Argo Watcher's own reason verbatim, got %q", health.Reason)
+	}
+	// The gauge tracks reachability, not readiness: both probes answered.
+	if metrics.reachable != 1 || metrics.unreachable != 0 {
+		t.Fatalf("expected reachability metrics reachable=1 unreachable=0, got %d/%d", metrics.reachable, metrics.unreachable)
+	}
+}
+
+func TestCheckUnreadyWithoutReasonFallsBackToStatus(t *testing.T) {
+	_, client, _ := newProbeServer(t, map[string]probeResponse{
+		"/livez":  {status: http.StatusOK, body: `{"status":"up"}`},
+		"/readyz": {status: http.StatusServiceUnavailable, body: `{"status":"down"}`},
+	})
+
+	health, err := client.Check(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if health.Ready || health.Reason != "status 503" {
+		t.Fatalf("expected unready with a status fallback reason, got %+v", health)
+	}
+}
+
+func TestCheckLivenessReportsDown(t *testing.T) {
+	_, client, metrics := newProbeServer(t, map[string]probeResponse{
+		"/livez": {status: http.StatusServiceUnavailable, body: `{"status":"down","reason":"shutting down"}`},
+	})
+
+	_, err := client.Check(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "shutting down") {
+		t.Fatalf("expected the error to carry Argo Watcher's reason, got %v", err)
 	}
 	if metrics.reachable != 0 || metrics.unreachable != 1 {
 		t.Fatalf("expected reachability metrics reachable=0 unreachable=1, got %d/%d", metrics.reachable, metrics.unreachable)
+	}
+}
+
+// A pre-split Argo Watcher answers /livez from the catch-all serving its Web UI.
+func TestCheckRejectsTheWebUIShell(t *testing.T) {
+	probes, client, metrics := newProbeServer(t, map[string]probeResponse{
+		"/livez": {status: http.StatusOK, body: "<!doctype html><title>Argo Watcher</title>"},
+	})
+
+	_, err := client.Check(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when /livez answers with something other than a probe payload")
+	}
+	if !strings.Contains(err.Error(), "no probe payload") {
+		t.Fatalf("expected the error to name the missing payload, got %v", err)
+	}
+	if got := strings.Join(probes.requested, ","); got != "/livez" {
+		t.Fatalf("expected /readyz not to be consulted, got %s", got)
+	}
+	if metrics.reachable != 0 || metrics.unreachable != 1 {
+		t.Fatalf("expected reachability metrics reachable=0 unreachable=1, got %d/%d", metrics.reachable, metrics.unreachable)
+	}
+}
+
+// Serving no probe endpoint means ARGO_WATCHER_URL points somewhere else, which
+// must be diagnosed by its status rather than blamed on the upstream version.
+func TestCheckNoProbeEndpoint(t *testing.T) {
+	_, client, metrics := newProbeServer(t, nil)
+
+	_, err := client.Check(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when the probe endpoint does not exist")
+	}
+	if !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("expected the error to report the observed status, got %v", err)
+	}
+	if strings.Contains(err.Error(), "probe payload") {
+		t.Fatalf("a 404 is an unreachable upstream, not a pre-split one, got %v", err)
+	}
+	if metrics.reachable != 0 || metrics.unreachable != 1 {
+		t.Fatalf("expected reachability metrics reachable=0 unreachable=1, got %d/%d", metrics.reachable, metrics.unreachable)
+	}
+}
+
+// An unobserved verdict must not be reported as ready.
+func TestCheckReadinessProbeFailureIsNotReady(t *testing.T) {
+	_, client, _ := newProbeServer(t, map[string]probeResponse{
+		"/livez":  {status: http.StatusOK, body: `{"status":"up"}`},
+		"/readyz": {status: http.StatusInternalServerError, body: "boom"},
+	})
+
+	health, err := client.Check(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if health.Ready || health.Reason != "status 500" {
+		t.Fatalf("expected unready with a status fallback reason, got %+v", health)
+	}
+}
+
+// The reason on a transport failure must stay bounded: this server serves it on
+// an unauthenticated endpoint, and the Go error names Argo Watcher's host.
+func TestCheckReadinessTransportFailureReasonIsBounded(t *testing.T) {
+	live := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"status":"up"}`)),
+	}
+	metrics := &trackingReachability{}
+	client := New("http://argo-watcher.internal:8080", &sequencedHTTPClient{
+		responses: []*http.Response{live},
+		err:       errors.New("dial tcp 10.1.2.3:8080: connect: connection refused"),
+	}, slog.New(slog.NewJSONHandler(io.Discard, nil)), WithReachabilityMetrics(metrics))
+
+	health, err := client.Check(context.Background())
+	if err != nil {
+		t.Fatalf("a failed readiness probe must not fail the check, got %v", err)
+	}
+	if health.Ready {
+		t.Fatal("expected unready when the readiness verdict could not be obtained")
+	}
+	if health.Reason != "readiness probe unreachable" {
+		t.Fatalf("expected a bounded reason, got %q", health.Reason)
+	}
+	// /livez answered, so the reachability gauge must survive the readiness failure.
+	if metrics.reachable != 1 || metrics.unreachable != 0 {
+		t.Fatalf("expected reachability metrics reachable=1 unreachable=0, got %d/%d", metrics.reachable, metrics.unreachable)
 	}
 }
 
@@ -408,12 +592,12 @@ func TestCheckNetworkError(t *testing.T) {
 	metrics := &trackingReachability{}
 	client := New("http://example.com", &mockHTTPClient{respErr: errors.New("connection refused")}, nil, WithReachabilityMetrics(metrics))
 
-	err := client.Check(context.Background())
+	_, err := client.Check(context.Background())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "health request") {
-		t.Fatalf("expected error to mention health request, got %v", err)
+	if !strings.Contains(err.Error(), "probe /livez") {
+		t.Fatalf("expected error to name the probe, got %v", err)
 	}
 	if metrics.reachable != 0 || metrics.unreachable != 1 {
 		t.Fatalf("expected reachability metrics reachable=0 unreachable=1, got %d/%d", metrics.reachable, metrics.unreachable)
@@ -441,8 +625,8 @@ func TestRequestBuildFailures(t *testing.T) {
 	metrics := &trackingReachability{}
 	client := New(invalidURL, &mockHTTPClient{}, nil, WithReachabilityMetrics(metrics))
 
-	if err := client.Check(context.Background()); err == nil || !strings.Contains(err.Error(), "build health request") {
-		t.Fatalf("expected build health request error, got %v", err)
+	if _, err := client.Check(context.Background()); err == nil || !strings.Contains(err.Error(), "build probe request") {
+		t.Fatalf("expected build probe request error, got %v", err)
 	}
 
 	_, err := client.ListDeployments(context.Background(), domain.DeploymentFilter{FromTimestamp: time.Now().Unix()})

--- a/internal/domain/deployment.go
+++ b/internal/domain/deployment.go
@@ -106,7 +106,21 @@ type ArgoWatcher interface {
 	GetServerInfo(ctx context.Context) (ServerInfo, error)
 }
 
-// HealthChecker reports readiness of downstream dependencies.
+// UpstreamHealth carries Argo Watcher's own readiness verdict. Reason names the
+// cause of an unready one in Argo Watcher's wording, or the observed status code
+// where it supplies none.
+type UpstreamHealth struct {
+	Ready  bool
+	Reason string
+}
+
+// HealthChecker reports whether Argo Watcher is answering, and what its own
+// readiness probe says about it.
 type HealthChecker interface {
-	Check(ctx context.Context) error
+	// Check errors only when Argo Watcher's process is not answering. An Argo
+	// Watcher that answers while reporting itself unready is a nil error and an
+	// unready UpstreamHealth: every replica of this server shares one Argo
+	// Watcher, so erroring would withdraw them all at once and take the
+	// get_reachability tool that names the cause out of reach with them.
+	Check(ctx context.Context) (UpstreamHealth, error)
 }

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -86,7 +86,8 @@ func NewRouter(logger *slog.Logger, checker domain.HealthChecker, mcpHandler htt
 			return
 		}
 
-		if err := checker.Check(r.Context()); err != nil {
+		upstream, err := checker.Check(r.Context())
+		if err != nil {
 			writeJSON(r.Context(), requestLogger, w, http.StatusServiceUnavailable, map[string]string{
 				"status": "not_ready",
 				"error":  err.Error(),
@@ -94,7 +95,13 @@ func NewRouter(logger *slog.Logger, checker domain.HealthChecker, mcpHandler htt
 			return
 		}
 
-		writeJSON(r.Context(), requestLogger, w, http.StatusOK, map[string]string{"status": "ready"})
+		payload := map[string]string{"status": "ready"}
+		if !upstream.Ready {
+			payload["argo_watcher"] = "not_ready"
+			payload["argo_watcher_reason"] = upstream.Reason
+		}
+
+		writeJSON(r.Context(), requestLogger, w, http.StatusOK, payload)
 	})
 
 	if promHandler != nil {

--- a/internal/httpserver/router_test.go
+++ b/internal/httpserver/router_test.go
@@ -11,18 +11,26 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/shini4i/argo-watcher-mcp/internal/domain"
 )
 
 type stubChecker struct {
-	err error
+	upstream domain.UpstreamHealth
+	err      error
 }
 
-func (s *stubChecker) Check(_ context.Context) error {
-	return s.err
+func (s *stubChecker) Check(_ context.Context) (domain.UpstreamHealth, error) {
+	return s.upstream, s.err
+}
+
+// readyChecker stands in for an argo-watcher that answers and reports itself ready.
+func readyChecker() *stubChecker {
+	return &stubChecker{upstream: domain.UpstreamHealth{Ready: true}}
 }
 
 func TestHealthEndpoints(t *testing.T) {
-	router := NewRouter(nil, &stubChecker{}, nil, false, nil)
+	router := NewRouter(nil, readyChecker(), nil, false, nil)
 	server := httptest.NewServer(router)
 	defer server.Close()
 
@@ -58,12 +66,61 @@ func TestReadinessFailures(t *testing.T) {
 	}
 }
 
+func TestReadinessReportsReadyUpstream(t *testing.T) {
+	router := NewRouter(nil, readyChecker(), nil, false, nil)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("ready request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"status":"ready"`) {
+		t.Fatalf("unexpected body: %s", string(body))
+	}
+	if strings.Contains(string(body), "argo_watcher") {
+		t.Fatalf("expected no upstream detail on a ready upstream, got %s", string(body))
+	}
+}
+
+// An unready argo-watcher is reported at 200 rather than acted on.
+func TestReadinessReportsUnreadyUpstream(t *testing.T) {
+	checker := &stubChecker{upstream: domain.UpstreamHealth{Reason: "state backend unreachable"}}
+	router := NewRouter(nil, checker, nil, false, nil)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("ready request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	for _, want := range []string{`"status":"ready"`, `"argo_watcher":"not_ready"`, `"argo_watcher_reason":"state backend unreachable"`} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("expected body to contain %s, got %s", want, string(body))
+		}
+	}
+}
+
 func TestRouterWithMCPHandler(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	router := NewRouter(nil, &stubChecker{}, handler, true, nil)
+	router := NewRouter(nil, readyChecker(), handler, true, nil)
 	server := httptest.NewServer(router)
 	defer server.Close()
 
@@ -85,7 +142,7 @@ func TestRouterWithMCPHandlerDisabled(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	router := NewRouter(nil, &stubChecker{}, handler, false, nil)
+	router := NewRouter(nil, readyChecker(), handler, false, nil)
 	server := httptest.NewServer(router)
 	defer server.Close()
 
@@ -104,7 +161,7 @@ func TestRouterWithMCPHandlerDisabled(t *testing.T) {
 }
 
 func TestRouterWithoutMCPHandler(t *testing.T) {
-	router := NewRouter(nil, &stubChecker{}, nil, false, nil)
+	router := NewRouter(nil, readyChecker(), nil, false, nil)
 	server := httptest.NewServer(router)
 	defer server.Close()
 
@@ -126,7 +183,7 @@ func TestRouterWithoutMCPHandler(t *testing.T) {
 
 func TestMetricsEndpointWithPrometheusHandler(t *testing.T) {
 	promHandler := promhttp.Handler()
-	router := NewRouter(nil, &stubChecker{}, nil, false, promHandler)
+	router := NewRouter(nil, readyChecker(), nil, false, promHandler)
 	server := httptest.NewServer(router)
 	defer server.Close()
 


### PR DESCRIPTION
argo-watcher replaces GET /healthz with /livez and /readyz (shini4i/argo-watcher#535). The readiness check now probes /livez to decide whether argo-watcher answers, and /readyz for its own verdict, which is reported in this server's /readyz body rather than acted on.

An unready argo-watcher no longer fails readiness here. Every replica shares one argo-watcher, so failing on its state backend withdrew all of them at once and took get_reachability -- the tool that names the cause -- out of reach with it. 503 is now reserved for an argo-watcher whose process does not answer.

A pre-split argo-watcher answers /livez from the catch-all serving its Web UI, at 200 with the HTML shell rather than a 404, so a probe response is recognised by its JSON payload instead of its status code. The endpoints are unreleased upstream: against v0.14.0 and older this server reports 503 with "no probe payload" instead of a readiness verdict read off a web page.

BREAKING CHANGE: /readyz answers 200 for an argo-watcher that is up but reports itself unready, naming the verdict as argo_watcher and argo_watcher_reason in the body; argo_watcher_reachable reads 1 in that state where it previously read 0. Alerts watching either for an argo-watcher state backend outage should watch get_reachability or argo-watcher's own metrics. A readiness probe wired to this server now requires an argo-watcher that serves /livez and /readyz.

Related PRs: https://github.com/shini4i/charts/pull/48 and https://github.com/shini4i/argo-watcher/pull/535